### PR TITLE
Empty case class support via ProductFormats.jsonFormat0

### DIFF
--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -23,6 +23,14 @@ package spray.json
 trait ProductFormats {
   this: StandardFormats =>
 
+  def jsonFormat0[T <: Product :ClassManifest](construct: () => T): RootJsonFormat[T] = {
+    jsonFormat(construct)
+  }
+  def jsonFormat[T <: Product](construct: () => T): RootJsonFormat[T] = new RootJsonFormat[T]{
+    def write(p: T) = JsObject()
+    def read(value: JsValue) = construct()
+  }
+
   def jsonFormat1[A :JF, T <: Product :ClassManifest](construct: A => T): RootJsonFormat[T] = {
     val Array(a) = extractFieldNames(classManifest[T])
     jsonFormat(construct, a)


### PR DESCRIPTION
Added a jsonFormat0 method to ProductFormats.scala to support empty case classes, for completeness.  Empty case classes are sometimes preferable to case objects, e.g. when integrating with Java code.

```
scala> import spray.json._
import spray.json._

scala> case class Empty()
defined class Empty

scala> object MyJsonProtocol extends DefaultJsonProtocol {
     |   implicit val emptyFormat = jsonFormat0(Empty)
     | }
defined module MyJsonProtocol

scala> import MyJsonProtocol._
import MyJsonProtocol._

scala> val json = Empty().toJson
json: spray.json.JsValue = {}

scala> val empty = json.convertTo[Empty]
empty: Empty = Empty()
```
