### PR TITLE
Added the requirement to import a JsonProtocol to the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,7 @@ _spray-json_ is really easy to use.
 Just bring all relevant elements in scope with 
 
     import spray.json._
+    import DefaultJsonProtocol._
 
 and do one or more of the following:
 


### PR DESCRIPTION
Added the requirement to import a JsonProtocol to the readme. This bit me, and apparently bit other people:

https://github.com/spray/spray-json/issues/11

and isn't hard to fix, really.
