### PR TITLE
Add OSGi metatadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,17 @@ scaladocOptions <<= (name, version).map { (n, v) => Seq("-doc-title", n + " " + 
 // generate boilerplate
 Boilerplate.settings
 
+// OSGi settings
+osgiSettings
+
+OsgiKeys.exportPackage := Seq("""spray.json.*;version="${Bundle-Version}"""")
+
+OsgiKeys.importPackage <<= scalaVersion { sv => Seq("""scala.*;version="$<range;[==,=+);%s>"""".format(sv)) }
+
+OsgiKeys.importPackage ++= Seq("""spray.json;version="${Bundle-Version}"""", "*")
+
+OsgiKeys.additionalHeaders := Map("-removeheaders" -> "Include-Resource,Private-Package")
+
 ///////////////
 // publishing
 ///////////////

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
 
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.5.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.5.0")


### PR DESCRIPTION
This PR adds OSGi metadata to the spray-json JAR. This PR is my original work and is granted to spray-json per the patch policy (http://spray.io/project-info/contributing/).
