### PR TITLE
Added name of malformed field to error message

### DIFF
--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -488,7 +488,7 @@ trait ProductFormats {
             if (reader.isInstanceOf[OptionFormat[_]]) None.asInstanceOf[T]
             else deserializationError("Object is missing required member '" + fieldName + "'", e)
         }
-      case _ => deserializationError(s"Object expected in field %s".format(fieldName))
+      case _ => deserializationError("Object expected in field " + fieldName)
     }
   }
 


### PR DESCRIPTION
I added name of malformed field to error message. Sometimes it's hard to debug what exactly wrong with JSON that came from 3rd-party service. Instead of comparing bad json with my case classes it would be nice just to know which field is wrong.
