### PR TITLE
Added selective field getters for JsObject

### DIFF
--- a/src/main/scala/spray/json/JsValue.scala
+++ b/src/main/scala/spray/json/JsValue.scala
@@ -51,6 +51,34 @@ sealed abstract class JsValue {
 case class JsObject(fields: Map[String, JsValue]) extends JsValue {
   override def asJsObject(errorMsg: String) = this
   def getFields(fieldNames: String*): Seq[JsValue] = fieldNames.flatMap(fields.get)
+
+  def getField(fieldName: String):Option[JsValue] = fields.get(fieldName)
+
+  def getString(fieldName: String):Either[String, String] = fields.get(fieldName) match {
+    case Some(JsString(str)) => Right(str)
+    case Some(x) => Left("Expected a JsString in field %s but got %s".format(fieldName, x))
+    case None => Left("Field %s is missing".format(fieldName))
+  }
+
+  def getNumber(fieldName: String):Either[String, BigDecimal] = fields.get(fieldName) match {
+    case Some(JsNumber(num)) => Right(num)
+    case Some(x) => Left("Expected a JsNumber in field %s but got %s".format(fieldName, x))
+    case None => Left("Field %s is missing".format(fieldName))
+  }
+
+  def getInt(fieldName: String):Either[String, Int] = getNumber(fieldName).right.map(_.toInt)
+
+  def getLong(fieldName: String):Either[String, Long] = getNumber(fieldName).right.map(_.toLong)
+
+  def getFloat(fieldName: String):Either[String, Double] = getNumber(fieldName).right.map(_.toFloat)
+
+  def getDouble(fieldName: String):Either[String, Double] = getNumber(fieldName).right.map(_.toDouble)
+
+  def getBoolean(fieldName: String):Either[String, Boolean] = fields.get(fieldName) match {
+    case Some(JsBoolean(bool)) => Right(bool)
+    case Some(x) => Left("Expected a JsBoolean in field %s but got %s".format(fieldName, x))
+    case None => Left("Field %s is missing".format(fieldName))
+  }
 }
 object JsObject {
   // we use a ListMap in order to preserve the field order

--- a/src/test/scala/spray/json/CustomFormatSpec.scala
+++ b/src/test/scala/spray/json/CustomFormatSpec.scala
@@ -22,7 +22,7 @@ class CustomFormatSpec extends Specification with DefaultJsonProtocol {
 
   case class MyType(name: String, value: Int)
 
-  implicit val MyTypeProtocol = new RootJsonFormat[MyType] {
+  val MyTypeProtocol = new RootJsonFormat[MyType] {
     def read(json: JsValue) = {
       json.asJsObject.getFields("name", "value") match {
         case Seq(JsString(name), JsNumber(value)) => MyType(name, value.toInt)
@@ -32,13 +32,55 @@ class CustomFormatSpec extends Specification with DefaultJsonProtocol {
     def write(obj: MyType) = JsObject("name" -> JsString(obj.name), "value" -> JsNumber(obj.value))
   }
 
+  val MyTypeProtocolWithOptionals = new RootJsonFormat[MyType] {
+
+    def maybeJsObject(json:JsValue):Either[String,JsObject] =
+      try{ Right(json.asJsObject) }
+      catch{ case e:Throwable => Left(e.getMessage)}
+
+    //this could be more elegant with a for comprehension but currently definitions are not allowed with either
+    //https://issues.scala-lang.org/browse/SI-5793
+    def maybeMyType(json:JsValue):Either[String,MyType] = maybeJsObject(json).right.flatMap{ obj =>
+      obj.getString("name").right.map{ name =>{
+        val value = obj.getInt("value").right.getOrElse(42)
+        MyType(name,value)
+      }}
+    }
+
+    def read(json: JsValue) = maybeMyType(json) match {
+      case Right(my) => my
+      case Left(error) => deserializationError(error)
+    }
+
+    def write(obj: MyType) = JsObject("name" -> JsString(obj.name), "value" -> JsNumber(obj.value))
+  }
+
   "A custom JsonFormat built with 'asJsonObject'" should {
     val value = MyType("bob", 42)
+
     "correctly deserialize valid JSON content" in {
+      implicit val format = MyTypeProtocol
       """{ "name": "bob", "value": 42 }""".asJson.convertTo[MyType] mustEqual value
     }
+
     "support full round-trip (de)serialization" in {
+      implicit val format = MyTypeProtocol
       value.toJson.convertTo[MyType] mustEqual value
+    }
+
+    "support optional parameters" in {
+      implicit val format = MyTypeProtocolWithOptionals
+      """{ "name": "bob" }""".asJson.convertTo[MyType] mustEqual value
+    }
+
+    "allow overriding default parameters" in{
+      implicit val format = MyTypeProtocolWithOptionals
+      """{ "name": "mike", "value": 123 }""".asJson.convertTo[MyType] mustEqual MyType("mike", 123)
+    }
+
+    "throw an exception if a required field is mission" in{
+      implicit val format = MyTypeProtocolWithOptionals
+      """{ "value": 123 }""".asJson.convertTo[MyType] must throwA(new DeserializationException("Field name is missing"))
     }
   }
 


### PR DESCRIPTION
When writing a custom `JsonFormat` the currently proposed way of using pattern matching/extractors on `JsObject.getFields` is elegant and concise especially when all the fields are required.

However we often meet the situation where, even though the fields in the domain object are required, we can provide default values for some of these fields, thus making some part of the incoming json optional. 

For example, a `User` class might require a `language` and `timezone` parameters but we we can use the system defaults if the incoming json does not specify these fields.

I experimented with multiple options that would make easier the writing of `JsonFormat`s that allow optional fields and I think the best one is to add specialised field getters in the JsObject class. Then `flatMap`/`map` or a for comprehension can be used in the `JsonFormat` to extract the fields as demonstrated in the test.
