### PR TITLE
Fix bug with invalid hex digits in JsonParser

### DIFF
--- a/src/main/scala/spray/json/JsonParser.scala
+++ b/src/main/scala/spray/json/JsonParser.scala
@@ -70,7 +70,7 @@ object JsonParser extends Parser {
 
   def Digit = rule { "0" - "9" }
 
-  def HexDigit = rule { "0" - "9" | "a" - "f" | "A" - "Z" }
+  def HexDigit = rule { "0" - "9" | "a" - "f" | "A" - "F" }
 
   def Frac = rule { "." ~ Digits }
 


### PR DESCRIPTION
Valid hex digits are `[0-9a-fA-F]`. The `"A" - "Z"` in `JsonParser.scala` is a typo, and should be changed to `"A" - "F"`

No other behavior has been changed. The code passes all unit tests.
