### PR TITLE
Ignore static fields in jsonFormat

### DIFF
--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -61,7 +61,9 @@ trait ProductFormats extends ProductFormatsInstances {
       // that lexical sorting of ...8(), ...9(), ...10() is not correct, so we extract N and sort by N.toInt
       val copyDefaultMethods = clazz.getMethods.filter(_.getName.startsWith("copy$default$")).sortBy(
         _.getName.drop("copy$default$".length).takeWhile(_ != '(').toInt)
-      val fields = clazz.getDeclaredFields.filterNot(f => f.getName.startsWith("$") || Modifier.isTransient(f.getModifiers))
+      val fields = clazz.getDeclaredFields.filterNot { f =>
+        f.getName.startsWith("$") || Modifier.isTransient(f.getModifiers) || Modifier.isStatic(f.getModifiers)
+      }
       if (copyDefaultMethods.length != fields.length)
         sys.error("Case class " + clazz.getName + " declares additional fields")
       if (fields.zip(copyDefaultMethods).exists { case (f, m) => f.getType != m.getReturnType })

--- a/src/test/scala/spray/json/ProductFormatsSpec.scala
+++ b/src/test/scala/spray/json/ProductFormatsSpec.scala
@@ -25,12 +25,15 @@ class ProductFormatsSpec extends Specification {
   case class TestTransient(a: Int, b: Option[Double]) {
     @transient var c = false
   }
+  @SerialVersionUID(1L) // SerialVersionUID adds a static field to the case class
+  case class TestStatic(a: Int, b: Option[Double])
 
   trait TestProtocol {
     this: DefaultJsonProtocol =>
     implicit val test2Format = jsonFormat2(Test2)
     implicit def test3Format[A: JsonFormat, B: JsonFormat] = jsonFormat2(Test3.apply[A, B])
     implicit def testTransientFormat = jsonFormat2(TestTransient)
+    implicit def testStaticFormat = jsonFormat2(TestStatic)
   }
   object TestProtocol1 extends DefaultJsonProtocol with TestProtocol
   object TestProtocol2 extends DefaultJsonProtocol with TestProtocol with NullOptions
@@ -144,6 +147,18 @@ class ProductFormatsSpec extends Specification {
     }
     "convert a JsObject to the respective case class instance" in {
       json.convertTo[TestTransient] mustEqual obj
+    }
+  }
+
+  "A JsonFormat for a case class with static fields and created with `jsonFormat`" should {
+    import TestProtocol1._
+    val obj = TestStatic(42, Some(4.2))
+    val json = JsObject("a" -> JsNumber(42), "b" -> JsNumber(4.2))
+    "convert to a respective JsObject" in {
+      obj.toJson mustEqual json
+    }
+    "convert a JsObject to the respective case class instance" in {
+      json.convertTo[TestStatic] mustEqual obj
     }
   }
 


### PR DESCRIPTION
When a case class has static fields, for example a <code>SerialVersionUID</code>, then you cannot use <code>jsonFormat</code>. Since these fields don't have to end up in the Format, these can just be ignored. This commit changes the behavior of <code>jsonFormat</code> to ignore static fields and then it is possible to serialize case classes with a static field.
