### PR TITLE
Make printer methods protected, so they can be overridden

### DIFF
--- a/src/main/scala/spray/json/CompactPrinter.scala
+++ b/src/main/scala/spray/json/CompactPrinter.scala
@@ -31,7 +31,7 @@ trait CompactPrinter extends JsonPrinter {
     }
   }
 
-  private def printObject(members: Map[String, JsValue], sb: StringBuilder) {
+  protected def printObject(members: Map[String, JsValue], sb: StringBuilder) {
     sb.append('{')
     printSeq(members, sb.append(',')) { m =>
       printString(m._1, sb)
@@ -41,7 +41,7 @@ trait CompactPrinter extends JsonPrinter {
     sb.append('}')
   }
 
-  private def printArray(elements: List[JsValue], sb: StringBuilder) {
+  protected def printArray(elements: List[JsValue], sb: StringBuilder) {
     sb.append('[')
     printSeq(elements, sb.append(','))(print(_, sb))
     sb.append(']')

--- a/src/main/scala/spray/json/PrettyPrinter.scala
+++ b/src/main/scala/spray/json/PrettyPrinter.scala
@@ -29,7 +29,7 @@ trait PrettyPrinter extends JsonPrinter {
     print(x, sb, 0)
   }
   
-  private def print(x: JsValue, sb: StringBuilder, indent: Int) {
+  protected def print(x: JsValue, sb: StringBuilder, indent: Int) {
     x match {
       case JsObject(x) => printObject(x, sb, indent)
       case JsArray(x)  => printArray(x, sb, indent)
@@ -37,7 +37,7 @@ trait PrettyPrinter extends JsonPrinter {
     }
   }
 
-  private def printObject(members: Map[String, JsValue], sb: StringBuilder, indent: Int) {
+  protected def printObject(members: Map[String, JsValue], sb: StringBuilder, indent: Int) {
     sb.append("{\n")    
     printSeq(members, sb.append(",\n")) { m =>
       printIndent(sb, indent + Indent)
@@ -50,14 +50,14 @@ trait PrettyPrinter extends JsonPrinter {
     sb.append("}")
   }
   
-  private def printArray(elements: List[JsValue], sb: StringBuilder, indent: Int) {
+  protected def printArray(elements: List[JsValue], sb: StringBuilder, indent: Int) {
     sb.append('[')
     printSeq(elements, sb.append(", "))(print(_, sb, indent))
     sb.append(']')
   }
   
   @tailrec
-  private def printIndent(sb: StringBuilder, indent: Int) {
+  protected def printIndent(sb: StringBuilder, indent: Int) {
     if (indent > 0) {
       sb.append(' ')
       printIndent(sb, indent - 1)


### PR DESCRIPTION
I want to make a custom `PrettyPrinter` that prints each array element on a new line. 

I looked at overriding `printArray`, but that is not possible when these methods are `private`. Can we make then `protected`? Or is there a better way to achieve what I'm trying to do?
