### PR TITLE
match spec tightly about which characters to encode, fixes #83, #46

### DIFF
--- a/src/test/scala/spray/json/CompactPrinterSpec.scala
+++ b/src/test/scala/spray/json/CompactPrinterSpec.scala
@@ -49,12 +49,16 @@ class CompactPrinterSpec extends Specification {
       CompactPrinter(JsString("xyz")) mustEqual "\"xyz\""
     }
     "properly escape special chars in JsString" in {
-      CompactPrinter(JsString("\"\\\b\f\n\r\t\u12AB")) mustEqual """"\"\\\b\f\n\r\t""" + "\\u12ab\""
-      CompactPrinter(JsString("\u1000")) mustEqual "\"\\u1000\""
-      CompactPrinter(JsString("\u0100")) mustEqual "\"\\u0100\""
+      CompactPrinter(JsString("\"\\\b\f\n\r\t")) mustEqual """"\"\\\b\f\n\r\t""""
+      CompactPrinter(JsString("\u1000")) mustEqual "\"\u1000\""
+      CompactPrinter(JsString("\u0100")) mustEqual "\"\u0100\""
       CompactPrinter(JsString("\u0010")) mustEqual "\"\\u0010\""
       CompactPrinter(JsString("\u0001")) mustEqual "\"\\u0001\""
       CompactPrinter(JsString("\u001e")) mustEqual "\"\\u001e\""
+      // don't escape as it isn't required by the spec
+      CompactPrinter(JsString("\u007f")) mustEqual "\"\u007f\""
+      CompactPrinter(JsString("飞机因此受到损伤")) mustEqual "\"飞机因此受到损伤\""
+      CompactPrinter(JsString("\uD834\uDD1E")) mustEqual "\"\uD834\uDD1E\""
     }
     "properly print a simple JsObject" in (
       CompactPrinter(JsObject("key" -> JsNumber(42), "key2" -> JsString("value")))

--- a/src/test/scala/spray/json/PrettyPrinterSpec.scala
+++ b/src/test/scala/spray/json/PrettyPrinterSpec.scala
@@ -58,7 +58,7 @@ class PrettyPrinterSpec extends Specification {
            |      "no": 0
            |    }, ["a", "b", null], false]
            |  }
-           |}""".stripMargin.replace("\u00f8", "\\u00f8")
+           |}""".stripMargin
       }
     }
   }


### PR DESCRIPTION
This is much more straight-forward than the previous solution but maybe also a bit slower.
