### PR TITLE
Support for Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= {
   })
 }
 
-scaladocOptions <<= (name, version).map { (n, v) => Seq("-doc-title", n + " " + v) }
+(scalacOptions in doc) <<= (name, version).map { (n, v) => Seq("-doc-title", n + " " + v) }
 
 // generate boilerplate
 Boilerplate.settings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
+addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.5.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.5.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")


### PR DESCRIPTION
Two changes:
1. Modify build definition to support (not crash) when Scala 2.11 is being used
2. Upgrade to sbt 0.13.x which allows us to plug spray-json into our [community build](https://github.com/typesafehub/community-builds) which we rebuild every night now

I'd appreciate speedy review of this PR.
