### PR TITLE
+ JsonPrinter : allow a length to be provided for string builder

### DIFF
--- a/src/main/scala/spray/json/CompactPrinter.scala
+++ b/src/main/scala/spray/json/CompactPrinter.scala
@@ -48,4 +48,10 @@ trait CompactPrinter extends JsonPrinter {
   }
 }
 
-object CompactPrinter extends CompactPrinter
+object CompactPrinter extends CompactPrinter {
+  def apply(expectedContentLength : Int) : CompactPrinter = {
+    new CompactPrinter {
+      override def expectedLength = expectedContentLength
+    }
+  }
+}

--- a/src/main/scala/spray/json/JsonPrinter.scala
+++ b/src/main/scala/spray/json/JsonPrinter.scala
@@ -24,12 +24,14 @@ import java.lang.StringBuilder
  */
 trait JsonPrinter extends (JsValue => String) {
 
+  def expectedLength = 16
+
   def apply(x: JsValue): String = apply(x, None)
 
   def apply(x: JsValue, jsonpCallback: String): String = apply(x, Some(jsonpCallback))
 
   def apply(x: JsValue, jsonpCallback: Option[String]): String = {
-    val sb = new StringBuilder
+    val sb = new StringBuilder(expectedLength)
     jsonpCallback match {
       case Some(callback) => {
         sb.append(callback).append('(')

--- a/src/main/scala/spray/json/PrettyPrinter.scala
+++ b/src/main/scala/spray/json/PrettyPrinter.scala
@@ -66,4 +66,10 @@ trait PrettyPrinter extends JsonPrinter {
   }
 }
 
-object PrettyPrinter extends PrettyPrinter
+object PrettyPrinter extends PrettyPrinter {
+  def apply(expectedContentLength : Int) : PrettyPrinter = {
+    new PrettyPrinter {
+      override def expectedLength = expectedContentLength
+    }
+  }
+}

--- a/src/test/scala/spray/json/CompactPrinterSpec.scala
+++ b/src/test/scala/spray/json/CompactPrinterSpec.scala
@@ -71,6 +71,18 @@ class CompactPrinterSpec extends Specification {
     "properly print a JSON padding (JSONP) if requested" in {
       CompactPrinter(JsTrue, Some("customCallback")) mustEqual("customCallback(true)")
     }
+    "allow a custom length and properly escape special chars in JsString" in {
+      CompactPrinter(32)(JsString("\"\\\b\f\n\r\t")) mustEqual """"\"\\\b\f\n\r\t""""
+      CompactPrinter(64)(JsString("\u1000")) mustEqual "\"\u1000\""
+      CompactPrinter(128)(JsString("\u0100")) mustEqual "\"\u0100\""
+      CompactPrinter(256)(JsString("\u0010")) mustEqual "\"\\u0010\""
+      CompactPrinter(512)(JsString("\u0001")) mustEqual "\"\\u0001\""
+      CompactPrinter(32)(JsString("\u001e")) mustEqual "\"\\u001e\""
+      // don't escape as it isn't required by the spec
+      CompactPrinter(16)(JsString("\u007f")) mustEqual "\"\u007f\""
+      CompactPrinter(8)(JsString("飞机因此受到损伤")) mustEqual "\"飞机因此受到损伤\""
+      CompactPrinter(2)(JsString("\uD834\uDD1E")) mustEqual "\"\uD834\uDD1E\""
+    }
   }
   
 }

--- a/src/test/scala/spray/json/PrettyPrinterSpec.scala
+++ b/src/test/scala/spray/json/PrettyPrinterSpec.scala
@@ -62,5 +62,48 @@ class PrettyPrinterSpec extends Specification {
       }
     }
   }
+
+  "The PrettyPrinter" should {
+    "allow a custom length and print a more complicated JsObject nicely aligned" in {
+      PrettyPrinter(64) {
+        JsonParser {
+          """|{
+            |  "simpleKey" : "some value",
+            |  "key with spaces": null,
+            |  "zero": 0,
+            |  "number": -1.2323424E-5,
+            |  "Boolean yes":true,
+            |  "Boolean no": false,
+            |  "Unic\u00f8de" :  "Long string with newline\nescape",
+            |  "key with \"quotes\"" : "string",
+            |  "sub object" : {
+            |    "sub key": 26.5,
+            |    "a": "b",
+            |    "array": [1, 2, { "yes":1, "no":0 }, ["a", "b", null], false]
+            |  }
+            |}""".stripMargin
+        }
+      } mustEqual {
+        """|{
+          |  "simpleKey": "some value",
+          |  "key with spaces": null,
+          |  "zero": 0,
+          |  "number": -0.000012323424,
+          |  "Boolean yes": true,
+          |  "Boolean no": false,
+          |  "Unic\u00f8de": "Long string with newline\nescape",
+          |  "key with \"quotes\"": "string",
+          |  "sub object": {
+          |    "sub key": 26.5,
+          |    "a": "b",
+          |    "array": [1, 2, {
+          |      "yes": 1,
+          |      "no": 0
+          |    }, ["a", "b", null], false]
+          |  }
+          |}""".stripMargin
+      }
+    }
+  }
   
 }


### PR DESCRIPTION
Hi there,

Is it possible to allow for the specification of the size of the buffer used by the CompactPrinter and the PrettyPrinter.  I noticed that the default size of 16chars is used, which causes a larger number of expansions to occur, increasing the amount memory allocations and TLAB pressure:

Here is an screen shot for a load test run of the default 16 chars

![stringbuilderexpand](https://cloud.githubusercontent.com/assets/211070/2910109/f67ee462-d63c-11e3-8fe6-78f1e8045c2b.png)

Here's the same execution, but being allowed to specify the size of the internal buffer:

![stringbuilderexpandreduction](https://cloud.githubusercontent.com/assets/211070/2910123/378a5a90-d63d-11e3-804f-7db40dd6447e.png)

---

Maybe there's another way to address the sizing of the internal buffer.  But I thought I'd highlight the expandCapacity impact.

thanks
/dom 
