### PR TITLE
+ jsonFormat : allow user to choose between ordered and unordered key/values

### DIFF
--- a/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
+++ b/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
@@ -36,7 +36,25 @@ trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
       ]
       construct([#p1V#])
     }
-  }#
+  }
+    def jsonUnorderedFormat1[[#P1 :JF#], T <: Product :ClassManifest](construct: ([#P1#]) => T): RootJsonFormat[T] = {
+      val Array([#p1#]) = extractFieldNames(classManifest[T])
+      jsonUnorderedFormat(construct, [#p1#])
+    }
+    def jsonUnorderedFormat[[#P1 :JF#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonFormat[T] = new RootJsonFormat[T]{
+      def write(p: T) = {
+        val fields = new collection.mutable.ListBuffer[(String, JsValue)]
+        fields.sizeHint(1 * 2)
+        [#fields ++= productElement##2Field[P1](fieldName1, p, 0)#
+        ]
+        JsObject(false,fields: _*)
+      }
+      def read(value: JsValue) = {
+        [#val p1V = fromField[P1](value, fieldName1)#
+        ]
+        construct([#p1V#])
+      }
+    }#
 
 
 ]

--- a/src/main/scala/spray/json/JsValue.scala
+++ b/src/main/scala/spray/json/JsValue.scala
@@ -55,7 +55,23 @@ case class JsObject(fields: Map[String, JsValue]) extends JsValue {
 object JsObject {
   // we use a ListMap in order to preserve the field order
   def apply(members: JsField*) = new JsObject(ListMap(members: _*))
+  def apply(ordered: Boolean, members: JsField*) = {
+    if(ordered) {
+      new JsObject(ListMap(members: _*))
+    }
+    else {
+      new JsObject(Map(members: _*))
+    }
+  }
   def apply(members: List[JsField]) = new JsObject(ListMap(members: _*))
+  def apply(ordered: Boolean, members: List[JsField]) = {
+    if(ordered) {
+      new JsObject(ListMap(members: _*))
+    } else {
+      new JsObject(Map(members: _*))
+    }
+  }
+
 }
 
 /**


### PR DESCRIPTION
Hi there,

As per the post here: https://groups.google.com/forum/#!topic/spray-user/bDiqD1Xfxls

I've made changes that can use Map in a JsObject, over ListMap, when the user does not require the ordering of the  attributes to appear in the same order as they appear in the domain/marshalled object; as the ordering of keys in an object in json isn't required (ordering is only required by Arrays as per the JSON.org specs).

The below image shows a ~7 min run of our load test, with Ordered elements (ListMap):

![listmapallocation](https://cloud.githubusercontent.com/assets/211070/2932378/b6e8a62a-d7af-11e3-9be4-d471b6993f7a.png)

The following is the same load test, but with this pull request to allow for a `jsonUnorderedFormat` formatters:

![mapreducedallocations](https://cloud.githubusercontent.com/assets/211070/2932385/de813742-d7af-11e3-8684-1fe32a40c49f.png)

the diagram shows the ~40gb drop in allocations as a result of using Map over ListMap; which is close 40% drop in allocations for the marshalling.

Apologies, I couldn't easily see an easy way to add a boolean to the existing `jsonFormat` templates; to control the ordering, so I just went for the explicit `jsonUnorderedFormat<num>` approach.  

thanks
/dom
