### PR TITLE
update the document to make it more accurate

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ If you use SBT you can include _spray-json_ in your project with
 ```scala
 resolvers += "spray" at "http://repo.spray.io/"
 
-libraryDependencies += "io.spray" %%  "spray-json" % "1.2.6"
+libraryDependencies += "io.spray" %%  "spray-json_<scala_version>" % "1.2.6"
 ```
 
 _spray-json_ has only one dependency: the parsing library [parboiled][]


### PR DESCRIPTION
to add `spray-json` as a dependency, you have to specify Scala version, this might be a commons sense for senior Scala programers, but it should be better to make ti more accurate.
