### PR TITLE
Add jsonFormat0 for fieldless case classes

### DIFF
--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -26,6 +26,15 @@ import scala.util.control.NonFatal
 trait ProductFormats extends ProductFormatsInstances {
   this: StandardFormats =>
 
+  def jsonFormat0[T](construct: () => T): RootJsonFormat[T] =
+    new RootJsonFormat[T] {
+      def write(p: T) = JsObject()
+      def read(value: JsValue) = value match {
+        case JsObject(_) => construct()
+        case _ => throw new DeserializationException("Object expected")
+      }
+    }
+
   // helpers
   
   protected def productElement2Field[T](fieldName: String, p: Product, ix: Int, rest: List[JsField] = Nil)


### PR DESCRIPTION
Implemented [maspwr's suggestion](https://github.com/spray/spray-json/issues/41#issuecomment-47947123) from #41:

> What would be nice is if spray-json at least serialized a parameterless case class as an empty JsObject.

This fits in pretty naturally with the other product formats.
