### PR TITLE
Fix parsing from bytes if first character of string is multi-byte

### DIFF
--- a/src/main/scala/spray/json/JsonParser.scala
+++ b/src/main/scala/spray/json/JsonParser.scala
@@ -124,7 +124,7 @@ class JsonParser(input: ParserInput) {
 
   // http://tools.ietf.org/html/rfc4627#section-2.5
   private def `string`(): Unit = {
-    require('"')
+    if (cursorChar == '"') cursorChar = input.nextUtf8Char() else fail("'\"'")
     sb.setLength(0)
     while (`char`()) cursorChar = input.nextUtf8Char()
     require('"')

--- a/src/test/scala/spray/json/JsonParserSpec.scala
+++ b/src/test/scala/spray/json/JsonParserSpec.scala
@@ -67,6 +67,10 @@ class JsonParserSpec extends Specification {
         "3-bytes" -> JsString("3-byte UTF-8 chars like ﾖ, ᄅ or ᐁ."))
       JsonParser(json.prettyPrint.getBytes("UTF-8")) === json
     }
+    "parse directly from UTF-8 encoded bytes when string starts with a multi-byte character" in {
+      val json = JsString("£0.99")
+      JsonParser(json.prettyPrint.getBytes("UTF-8")) === json
+    }
     "be reentrant" in {
       val largeJsonSource = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/test.json")).mkString
       List.fill(20)(largeJsonSource).par.map(JsonParser(_)).toList.map {


### PR DESCRIPTION
In my environment, parsing the byte array of "£0.99" with spray-json incorrectly decodes the pound symbol as ASCII.  This fix modifies the `advance` function to advance 1 UTF-8 character rather than a single byte.