### PR TITLE
Reinstated deprecated JsArray and JsObject List based constructors for backwards compatibility

### DIFF
--- a/src/main/scala/spray/json/JsValue.scala
+++ b/src/main/scala/spray/json/JsValue.scala
@@ -53,14 +53,21 @@ case class JsObject(fields: Map[String, JsValue]) extends JsValue {
 }
 object JsObject {
   def apply(members: JsField*) = new JsObject(Map(members: _*))
+  @deprecated("Use JsObject(JsValue*) instead", "1.3.0")
+  def apply(members: List[JsField]) = new JsObject(Map(members: _*))
 }
 
 /**
   * A JSON array.
  */
-case class JsArray(elements: Vector[JsValue]) extends JsValue
+case class JsArray(elements: Vector[JsValue]) extends JsValue {
+  @deprecated("Use JsArray(Vector[JsValue]) instead", "1.3.0")
+  def this(elements: List[JsValue]) = this(elements.toVector)
+}
 object JsArray {
   def apply(elements: JsValue*) = new JsArray(elements.toVector)
+  @deprecated("Use JsArray(Vector[JsValue]) instead", "1.3.0")
+  def apply(elements: List[JsValue]) = new JsArray(elements.toVector)
 }
 
 /**


### PR DESCRIPTION
I saw that sbt-web was using spray-client 1.3 but spray-json 1.2, so I upgraded it to use spray-json 1.3.  This unfortunately has broken very sbt web plugin that uses JsArray.apply and JsObject.apply, which is a lot of them - they don't do anything complex with spray-json, but they do construct AST.  This change should make the spray-json 1.3 JsValue APIs binary compatible with 1.2, which I think is a good idea anyway given the centrality of the JsValue AST APIs, but would also really help me out.