### PR TITLE
Expose fieldName when able in deserialization errors

### DIFF
--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -56,9 +56,11 @@ trait ProductFormats extends ProductFormatsInstances {
       try reader.read(x.fields(fieldName))
       catch {
         case e: NoSuchElementException =>
-          deserializationError("Object is missing required member '" + fieldName + "'", e)
+          deserializationError("Object is missing required member '" + fieldName + "'", e, fieldName :: Nil)
+        case DeserializationException(msg, cause, fieldNames) =>
+          deserializationError(msg, cause, fieldName :: fieldNames)
       }
-    case _ => deserializationError("Object expected in field '" + fieldName + "'")
+    case _ => deserializationError("Object expected in field '" + fieldName + "'", fieldNames = fieldName :: Nil)
   }
 
   protected def extractFieldNames(classManifest: ClassManifest[_]): Array[String] = {

--- a/src/main/scala/spray/json/package.scala
+++ b/src/main/scala/spray/json/package.scala
@@ -20,7 +20,7 @@ package object json {
 
   type JsField = (String, JsValue)
 
-  def deserializationError(msg: String, cause: Throwable = null) = throw new DeserializationException(msg, cause)
+  def deserializationError(msg: String, cause: Throwable = null, fieldNames: List[String] = Nil) = throw new DeserializationException(msg, cause, fieldNames)
   def serializationError(msg: String) = throw new SerializationException(msg)
 
   def jsonReader[T](implicit reader: JsonReader[T]) = reader
@@ -32,7 +32,7 @@ package object json {
 
 package json {
 
-  class DeserializationException(msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
+  case class DeserializationException(msg: String, cause: Throwable = null, fieldNames: List[String] = Nil) extends RuntimeException(msg, cause)
   class SerializationException(msg: String) extends RuntimeException(msg)
 
   private[json] class PimpedAny[T](any: T) {


### PR DESCRIPTION
The use case for this PR is a REST API whose error responses must identify which field is missing or malformed.

The change is simple and backward compatible -- change `DeserializationException` to a case class with an optional `fieldName`, and add an optional `fieldName` arg to `deserializationError()`.  This allows apps to do things like this:

```scala
  implicit def rejectionHandler = RejectionHandler {
    case MalformedRequestContentRejection(message, cause) :: _ =>
      cause match {
        case DeserializationException(_, _, Some(fieldName)) =>
          ...the error response can be specific about fieldName
```