### PR TITLE
+#182 allows BigInt/BigDecimal to be obtained from JsStrings

### DIFF
--- a/src/main/scala/spray/json/BasicFormats.scala
+++ b/src/main/scala/spray/json/BasicFormats.scala
@@ -79,6 +79,7 @@ trait BasicFormats {
     }
     def read(value: JsValue) = value match {
       case JsNumber(x) => x
+      case JsString(x) => BigDecimal(x)
       case x => deserializationError("Expected BigDecimal as JsNumber, but got " + x)
     }
   }
@@ -90,6 +91,7 @@ trait BasicFormats {
     }
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.toBigInt
+      case JsString(x) => BigInt(x)
       case x => deserializationError("Expected BigInt as JsNumber, but got " + x)
     }
   }

--- a/src/test/scala/spray/json/BasicFormatsSpec.scala
+++ b/src/test/scala/spray/json/BasicFormatsSpec.scala
@@ -105,6 +105,9 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
     "convert a JsNumber to a BigDecimal" in {
       JsNumber(42).convertTo[BigDecimal] mustEqual BigDecimal(42)
     }
+    """convert a JsString to a BigDecimal (to allow the quoted-large-numbers pattern)""" in {
+      JsString("9223372036854775809").convertTo[BigDecimal] mustEqual BigDecimal("9223372036854775809")
+    }
   }
   
   "The BigIntJsonFormat" should {
@@ -113,6 +116,9 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
     }
     "convert a JsNumber to a BigInt" in {
       JsNumber(42).convertTo[BigInt] mustEqual BigInt(42)
+    }
+    """convert a JsString to a BigInt (to allow the quoted-large-numbers pattern)""" in {
+      JsString("9223372036854775809").convertTo[BigInt] mustEqual BigInt("9223372036854775809")
     }
   }
   


### PR DESCRIPTION
Resolves https://github.com/spray/spray-json/issues/182

Hopefully non-controversial, as it does not slow down the typical case of parsing from number