### PR TITLE
Fixed warning about unit.

### DIFF
--- a/src/test/scala/spray/json/BasicFormatsSpec.scala
+++ b/src/test/scala/spray/json/BasicFormatsSpec.scala
@@ -127,7 +127,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       ().toJson mustEqual JsNumber(1)
     }
     "convert a JsNumber to Unit" in {
-      JsNumber(1).convertTo[Unit] mustEqual ()
+      JsNumber(1).convertTo[Unit] mustEqual (())
     }
   }
   


### PR DESCRIPTION
In scala 2.11 and later, warning message is output if try to
interpret it automatically with the value of Unit when simply
writing "()".

Therefore, write "(())".