### PR TITLE
Correctly convert a Float to a JsNumber using BigDecimal#decimal

### DIFF
--- a/src/main/scala/spray/json/JsValue.scala
+++ b/src/main/scala/spray/json/JsValue.scala
@@ -92,6 +92,11 @@ object JsNumber {
   val zero: JsNumber = apply(0)
   def apply(n: Int) = new JsNumber(BigDecimal(n))
   def apply(n: Long) = new JsNumber(BigDecimal(n))
+  def apply(n: Float) = n match {
+    case n if n.isNaN      => JsNull
+    case n if n.isInfinity => JsNull
+    case _                 => new JsNumber(BigDecimal(java.lang.Float.toString(n)))
+  }
   def apply(n: Double) = n match {
     case n if n.isNaN      => JsNull
     case n if n.isInfinity => JsNull

--- a/src/test/scala/spray/json/BasicFormatsSpec.scala
+++ b/src/test/scala/spray/json/BasicFormatsSpec.scala
@@ -53,6 +53,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
   "The FloatJsonFormat" should {
     "convert a Float to a JsNumber" in {
       4.2f.toJson mustEqual JsNumber(4.2f)
+      4.2f.toJson.toString mustEqual "4.2"
     }
     "convert a Float.NaN to a JsNull" in {
       Float.NaN.toJson mustEqual JsNull
@@ -64,13 +65,13 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       Float.NegativeInfinity.toJson mustEqual JsNull
     }
     "convert a JsNumber to a Float" in {
-      JsNumber(4.2f).convertTo[Float] mustEqual 4.2f
+      "4.2".parseJson.convertTo[Float] mustEqual 4.2f
     }
     "convert a JsNull to a Float" in {
-      JsNull.convertTo[Float].isNaN mustEqual Float.NaN.isNaN
+      "null".parseJson.convertTo[Float].isNaN mustEqual Float.NaN.isNaN
     }
   }
-  
+
   "The DoubleJsonFormat" should {
     "convert a Double to a JsNumber" in {
       4.2.toJson mustEqual JsNumber(4.2)


### PR DESCRIPTION
When converting Floats to a JsNumber they will not be converted exact. The issue appears to be in `JsNumber.apply` (https://github.com/spray/spray-json/blob/master/src/main/scala/spray/json/JsValue.scala#L97) where the Float should be converted to a `BigDecimal` using `BigDecimal.decimal` rather than `BigDecimal` (see documentation there).

see https://github.com/spray/spray-json/issues/109 