### PR TITLE
Add a BasicFormat for java.lang.Number

### DIFF
--- a/src/test/scala/spray/json/BasicFormatsSpec.scala
+++ b/src/test/scala/spray/json/BasicFormatsSpec.scala
@@ -16,6 +16,8 @@
 
 package spray.json
 
+import java.math.BigInteger
+
 import org.specs2.mutable._
 
 class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
@@ -28,7 +30,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNumber(42).convertTo[Int] mustEqual 42
     }
   }
-  
+
   "The LongJsonFormat" should {
     "convert a Long to a JsNumber" in {
       7563661897011259335L.toJson mustEqual JsNumber(7563661897011259335L)
@@ -37,7 +39,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNumber(7563661897011259335L).convertTo[Long] mustEqual 7563661897011259335L
     }
   }
-  
+
   "The FloatJsonFormat" should {
     "convert a Float to a JsNumber" in {
       4.2f.toJson mustEqual JsNumber(4.2f)
@@ -58,7 +60,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNull.convertTo[Float].isNaN mustEqual Float.NaN.isNaN
     }
   }
-  
+
   "The DoubleJsonFormat" should {
     "convert a Double to a JsNumber" in {
       4.2.toJson mustEqual JsNumber(4.2)
@@ -79,7 +81,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNull.convertTo[Double].isNaN mustEqual Double.NaN.isNaN
     }
   }
-  
+
   "The ByteJsonFormat" should {
     "convert a Byte to a JsNumber" in {
       42.asInstanceOf[Byte].toJson mustEqual JsNumber(42)
@@ -88,7 +90,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNumber(42).convertTo[Byte] mustEqual 42
     }
   }
-  
+
   "The ShortJsonFormat" should {
     "convert a Short to a JsNumber" in {
       42.asInstanceOf[Short].toJson mustEqual JsNumber(42)
@@ -97,7 +99,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNumber(42).convertTo[Short] mustEqual 42
     }
   }
-  
+
   "The BigDecimalJsonFormat" should {
     "convert a BigDecimal to a JsNumber" in {
       BigDecimal(42).toJson mustEqual JsNumber(42)
@@ -109,7 +111,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsString("9223372036854775809").convertTo[BigDecimal] mustEqual BigDecimal("9223372036854775809")
     }
   }
-  
+
   "The BigIntJsonFormat" should {
     "convert a BigInt to a JsNumber" in {
       BigInt(42).toJson mustEqual JsNumber(42)
@@ -121,7 +123,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsString("9223372036854775809").convertTo[BigInt] mustEqual BigInt("9223372036854775809")
     }
   }
-  
+
   "The UnitJsonFormat" should {
     "convert Unit to a JsNumber(1)" in {
       ().toJson mustEqual JsNumber(1)
@@ -130,14 +132,14 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsNumber(1).convertTo[Unit] mustEqual (())
     }
   }
-  
+
   "The BooleanJsonFormat" should {
     "convert true to a JsTrue" in { true.toJson mustEqual JsTrue }
     "convert false to a JsFalse" in { false.toJson mustEqual JsFalse }
     "convert a JsTrue to true" in { JsTrue.convertTo[Boolean] mustEqual true }
     "convert a JsFalse to false" in { JsFalse.convertTo[Boolean] mustEqual false }
   }
-  
+
   "The CharJsonFormat" should {
     "convert a Char to a JsString" in {
       'c'.toJson mustEqual JsString("c")
@@ -146,7 +148,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsString("c").convertTo[Char] mustEqual 'c'
     }
   }
-  
+
   "The StringJsonFormat" should {
     "convert a String to a JsString" in {
       "Hello".toJson mustEqual JsString("Hello")
@@ -155,7 +157,7 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsString("Hello").convertTo[String] mustEqual "Hello"
     }
   }
-  
+
   "The SymbolJsonFormat" should {
     "convert a Symbol to a JsString" in {
       'Hello.toJson mustEqual JsString("Hello")
@@ -164,5 +166,33 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
       JsString("Hello").convertTo[Symbol] mustEqual 'Hello
     }
   }
-  
+
+  "The NumberJsonFormat" should {
+    "convert correctly to a JsNumber" in {
+      Short.MaxValue.asInstanceOf[Number].toJson mustEqual JsNumber(Short.MaxValue)
+      Int.MaxValue.asInstanceOf[Number].toJson mustEqual JsNumber(Int.MaxValue)
+      Long.MaxValue.asInstanceOf[Number].toJson mustEqual JsNumber(Long.MaxValue)
+      Float.MaxValue.asInstanceOf[Number].toJson mustEqual JsNumber(Float.MaxValue)
+      Double.MaxValue.asInstanceOf[Number].toJson mustEqual JsNumber(Double.MaxValue)
+      BigInteger.valueOf(new java.lang.Long(500)).asInstanceOf[Number].toJson mustEqual JsNumber(BigInteger.valueOf(new java.lang.Long(500)))
+      java.math.BigDecimal.valueOf(new java.lang.Double(500.55)).asInstanceOf[Number].toJson mustEqual JsNumber(java.math.BigDecimal.valueOf(new java.lang.Double(500.55)))
+      BigInt(Long.MaxValue + 1).asInstanceOf[Number].toJson mustEqual JsNumber(BigInt(Long.MaxValue + 1))
+      BigDecimal(500.55).asInstanceOf[Number].toJson mustEqual JsNumber(BigDecimal(500.55))
+      Byte.MaxValue.asInstanceOf[Number].toJson mustEqual JsNumber(Byte.MaxValue)
+      null.asInstanceOf[Number].toJson mustEqual JsNull
+    }
+    "convert a JsNumber to a Number" in {
+      JsNumber(Short.MaxValue).convertTo[Number] mustEqual Short.MaxValue
+      JsNumber(Int.MaxValue).convertTo[Number] mustEqual Int.MaxValue
+      JsNumber(Long.MaxValue).convertTo[Number] mustEqual Long.MaxValue
+      JsNumber(Float.MaxValue).convertTo[Number] mustEqual Float.MaxValue
+      JsNumber(Double.MaxValue).convertTo[Number] mustEqual Double.MaxValue
+      JsNumber(BigInteger.valueOf(new java.lang.Long(500))).convertTo[Number] mustEqual 500.toShort
+      JsNumber(java.math.BigDecimal.valueOf(new java.lang.Double(500.55))).convertTo[Number] mustEqual 500.55f
+      JsNumber(BigInt(Long.MaxValue + 1)).convertTo[Number] mustEqual BigInt(Long.MaxValue + 1)
+      JsNumber(BigDecimal(Double.MaxValue + 1.00)).convertTo[Number] mustEqual BigDecimal(Double.MaxValue + 1.00)
+      JsNumber(Byte.MaxValue).convertTo[Number] mustEqual Byte.MaxValue
+      JsNull.convertTo[Number] mustEqual null
+    }
+  }
 }


### PR DESCRIPTION
Trying to add a format for `Number`. Probably not perfect yet, feel free to comment. One issue is that when you convert a `Long(500)` to Json and back you'll end up having a `Short(500)`. 

see #43 