### PR TITLE
Add jsonReader and jsonWriter functions for constructing readers and writers for case classes

### DIFF
--- a/src/main/boilerplate/spray/json/ProductReadersInstances.scala.template
+++ b/src/main/boilerplate/spray/json/ProductReadersInstances.scala.template
@@ -16,19 +16,19 @@
 
 package spray.json
 
-trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
+trait ProductReadersInstances { self: ProductFormats with StandardFormats =>
 [#  // Case classes with 1 parameters
 
-  def jsonFormat1[[#P1 :JF#], T <: Product :ClassManifest](construct: ([#P1#]) => T): RootJsonFormat[T] = {
+  def jsonReader1[[#P1 :JsonReader#], T <: Product :ClassManifest](construct: ([#P1#]) => T): RootJsonReader[T] = {
     val Array([#p1#]) = extractFieldNames(classManifest[T])
-    jsonFormat(construct, [#p1#])
+    jsonReader(construct, [#p1#])
   }
-  def jsonFormat[[#P1 :JF#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonFormat[T] = new RootJsonFormat[T]{
-    val writer = jsonWriter(construct, [#fieldName1: String#])
-    val reader = jsonReader(construct, [#fieldName1: String#])
-
-    def write(p: T) = writer.write(p)
-    def read(value: JsValue) = reader.read(value)
+  def jsonReader[[#P1 :JsonReader#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonReader[T] = new RootJsonReader[T]{
+    def read(value: JsValue) = {
+      [#val p1V = fromField[P1](value, fieldName1)#
+      ]
+      construct([#p1V#])
+    }
   }#
 
 

--- a/src/main/boilerplate/spray/json/ProductWritersInstances.scala.template
+++ b/src/main/boilerplate/spray/json/ProductWritersInstances.scala.template
@@ -16,19 +16,21 @@
 
 package spray.json
 
-trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
+trait ProductWritersInstances { self: ProductFormats with StandardFormats =>
 [#  // Case classes with 1 parameters
 
-  def jsonFormat1[[#P1 :JF#], T <: Product :ClassManifest](construct: ([#P1#]) => T): RootJsonFormat[T] = {
+  def jsonWriter1[[#P1 :JsonWriter#], T <: Product :ClassManifest](construct: ([#P1#]) => T): RootJsonWriter[T] = {
     val Array([#p1#]) = extractFieldNames(classManifest[T])
-    jsonFormat(construct, [#p1#])
+    jsonWriter(construct, [#p1#])
   }
-  def jsonFormat[[#P1 :JF#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonFormat[T] = new RootJsonFormat[T]{
-    val writer = jsonWriter(construct, [#fieldName1: String#])
-    val reader = jsonReader(construct, [#fieldName1: String#])
-
-    def write(p: T) = writer.write(p)
-    def read(value: JsValue) = reader.read(value)
+  def jsonWriter[[#P1 :JsonWriter#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonWriter[T] = new RootJsonWriter[T]{
+    def write(p: T) = {
+      val fields = new collection.mutable.ListBuffer[(String, JsValue)]
+      fields.sizeHint(1 * 2)
+      [#fields ++= productElement##2Field[P1](fieldName1, p, 0)#
+      ]
+      JsObject(fields: _*)
+    }
   }#
 
 

--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -24,7 +24,7 @@ import scala.util.control.NonFatal
  * Provides the helpers for constructing custom JsonFormat implementations for types implementing the Product trait
  * (especially case classes)
  */
-trait ProductFormats extends ProductFormatsInstances {
+trait ProductFormats extends ProductFormatsInstances with ProductWritersInstances with ProductReadersInstances {
   this: StandardFormats =>
 
   def jsonFormat0[T](construct: () => T): RootJsonFormat[T] =

--- a/src/test/scala/spray/json/AdditionalFormatsSpec.scala
+++ b/src/test/scala/spray/json/AdditionalFormatsSpec.scala
@@ -26,7 +26,7 @@ class AdditionalFormatsSpec extends Specification {
     implicit def containerReader[T :JsonFormat] = lift {
       new JsonReader[Container[T]] {
         def read(value: JsValue) = value match {
-          case JsObject(fields) if fields.contains("content") => Container(Some(jsonReader[T].read(fields("content"))))
+          case JsObject(fields) if fields.contains("content") => Container(Some(spray.json.jsonReader[T].read(fields("content"))))
           case _ => deserializationError("Unexpected format: " + value.toString)
         }
       }


### PR DESCRIPTION
Hi,

There are functions like `jsonFormat3` that create `JsonFormat` objects for case classes. Sometimes you need only readers or writers, because you are developing client or server side of an api. There is no problem, `JsonFormat` extends both. But there are situations when you have your type with custom serialisation logic, eg. serialising `sealed trait`, and you are developing eg. only api server side. So in such situations it would be good to define only writers for your's case classes in order to avoid defining unnecessary `read` function for your exemplary `sealed trait`. This PR provides such functions, analogous to `jsonFormat` familly.

This PR doesn't provide any new tests, because `jsonFormat` functions have been refactored and they use new functions internally, so `ProductFormatsSpec` tests new functions as well.