### PR TITLE
Check mima against more than one version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,10 @@ OsgiKeys.additionalHeaders := Map("-removeheaders" -> "Include-Resource,Private-
 // Migration Manager
 mimaPreviousArtifacts := (CrossVersion.partialVersion(scalaVersion.value) match {
   case Some((2, 13)) => Set.empty
-  case _ => Set("io.spray" %% "spray-json" % "1.3.3")
+  case _ =>
+    Set("1.3.2", "1.3.3", "1.3.4").map { v =>
+      "io.spray" %% "spray-json" % v
+    }
 })
 
 mimaBinaryIssueFilters := Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.6


### PR DESCRIPTION
It seems 1.3.0 and 1.3.1 are not fully compatible any more and we didn't add filters, so let's keep it that way for now.