### PR TITLE
Replace ClassManifest usages by ClassTag

### DIFF
--- a/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
+++ b/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
@@ -16,11 +16,13 @@
 
 package spray.json
 
+import scala.reflect.{ classTag, ClassTag }
+
 trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
 [#  // Case classes with 1 parameters
 
-  def jsonFormat1[[#P1 :JF#], T <: Product :ClassManifest](construct: ([#P1#]) => T): RootJsonFormat[T] = {
-    val Array([#p1#]) = extractFieldNames(classManifest[T])
+  private[json] def jsonFormat1[[#P1 :JF#], T <: Product :ClassTag](construct: ([#P1#]) => T): RootJsonFormat[T] = {
+    val Array([#p1#]) = extractFieldNames(classTag[T])
     jsonFormat(construct, [#p1#])
   }
   def jsonFormat[[#P1 :JF#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonFormat[T] = new RootJsonFormat[T]{

--- a/src/main/scala/spray/json/CollectionFormats.scala
+++ b/src/main/scala/spray/json/CollectionFormats.scala
@@ -17,6 +17,8 @@
 
 package spray.json
 
+import scala.reflect.ClassTag
+
 trait CollectionFormats {
 
   /**
@@ -33,7 +35,7 @@ trait CollectionFormats {
   /**
     * Supplies the JsonFormat for Arrays.
    */
-  implicit def arrayFormat[T :JsonFormat :ClassManifest] = new RootJsonFormat[Array[T]] {
+  implicit def arrayFormat[T :JsonFormat :ClassTag] = new RootJsonFormat[Array[T]] {
     def write(array: Array[T]) = JsArray(array.map(_.toJson).toVector)
     def read(value: JsValue) = value match {
       case JsArray(elements) => elements.map(_.convertTo[T]).toArray[T]

--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -16,6 +16,7 @@
 
 package spray.json
 
+import scala.reflect.ClassTag
 import java.lang.reflect.Modifier
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
@@ -64,8 +65,8 @@ trait ProductFormats extends ProductFormatsInstances {
     case _ => deserializationError("Object expected in field '" + fieldName + "'", fieldNames = fieldName :: Nil)
   }
 
-  protected def extractFieldNames(classManifest: ClassManifest[_]): Array[String] = {
-    val clazz = classManifest.erasure
+  protected def extractFieldNames(classTag: ClassTag[_]): Array[String] = {
+    val clazz = classTag.runtimeClass
     try {
       // copy methods have the form copy$default$N(), we need to sort them in order, but must account for the fact
       // that lexical sorting of ...8(), ...9(), ...10() is not correct, so we extract N and sort by N.toInt


### PR DESCRIPTION
Binary compatible because `ClassManifest` is an alias to `ClassTag` since its
inception.

Fixes #215.