### PR TITLE
check num of fields in JSON match num of fields in case class

### DIFF
--- a/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
+++ b/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
@@ -34,6 +34,10 @@ trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
       JsObject(fields: _*)
     }
     def read(value: JsValue) = {
+      val fields = getJsValueFields(value)
+      if (fields.size != 1) {
+        deserializationError("Number of fields in JSON does not equal to target class")
+      }
       [#val p1V = fromField[P1](value, fieldName1)#
       ]
       construct([#p1V#])

--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -32,7 +32,11 @@ trait ProductFormats extends ProductFormatsInstances {
     new RootJsonFormat[T] {
       def write(p: T) = JsObject()
       def read(value: JsValue) = value match {
-        case JsObject(_) => construct()
+        case JsObject(fields) =>
+          if (fields.size > 0) {
+            throw new DeserializationException(s"Redundant fields: ${fields.keys.mkString(",")}")
+          }
+          construct()
         case _ => throw new DeserializationException("Object expected")
       }
     }
@@ -63,6 +67,12 @@ trait ProductFormats extends ProductFormatsInstances {
           deserializationError(msg, cause, fieldName :: fieldNames)
       }
     case _ => deserializationError("Object expected in field '" + fieldName + "'", fieldNames = fieldName :: Nil)
+  }
+
+  protected def getJsValueFields(value: JsValue) = value match {
+    case JsObject(fields) => fields
+    case _ => deserializationError("object expected!")
+
   }
 
   protected def extractFieldNames(tag: ClassTag[_]): Array[String] = {


### PR DESCRIPTION
Following code shows case class will be accidentally parsed to different case class in some cases,
so I think check number of fields is necessary.

```
case class Alert(name: String) extends Entity with Serializable
case class PerfCounterAlert(name: String, expression: String) extends Entity with Serializable

val perfCounterAlert = PerfCounterAlert("counter1", "value > 0")
val json = perfCounterAlert.toJson.prettyPrint
val deserializedRules = json.parseJson.convertTo[Alert]
```