### PR TITLE
Add "-release 8" to make sure we can produce working builds on JDK9+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val sprayJson =
       name := "spray-json",
       version := "1.3.6-SNAPSHOT",
       scalaVersion := crossScalaVersions.value.head,
-      scalacOptions ++= Seq("-feature", "-language:_", "-unchecked", "-deprecation", "-Xlint", "-encoding", "utf8"),
+      scalacOptions ++= Seq("-feature", "-language:_", "-unchecked", "-deprecation", "-Xlint", "-encoding", "utf8", "-target:jvm-1.8"),
       scalacOptions ++= {
         if (scalaMinorVersion.value >= 12) Seq("-release", "8")
         else Nil


### PR DESCRIPTION
Also drop support for Scala 2.10 and 2.11 which don't support the `-release` flag yet.