### PR TITLE
Move implicits to correct companion object

### DIFF
--- a/spray-json/js/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
+++ b/spray-json/js/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
@@ -1,0 +1,1 @@
+../../../../../../shared/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template

--- a/spray-json/js/src/main/scala/spray/json/ProductFormats.scala
+++ b/spray-json/js/src/main/scala/spray/json/ProductFormats.scala
@@ -37,8 +37,8 @@ trait ProductFormats extends ProductFormatsInstances {
   protected def productElement2Field[T](fieldName: String, p: Product, ix: Int, rest: List[JsField] = Nil)(implicit writer: JsonWriter[T]): List[JsField] = {
     val value = p.productElement(ix).asInstanceOf[T]
     writer match {
-      case _: OptionFormat[_] if (value == None) => rest
-      case _                                     => (fieldName, writer.write(value)) :: rest
+      case _: StandardFormats#OptionFormat[_] if (value == None) => rest
+      case _ => (fieldName, writer.write(value)) :: rest
     }
   }
 

--- a/spray-json/jvm/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
+++ b/spray-json/jvm/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
@@ -1,0 +1,1 @@
+../../../../../../shared/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template

--- a/spray-json/jvm/src/main/mima-filters/1.3.5.backwards.excludes/309-implicits-in-companion-objects.excludes
+++ b/spray-json/jvm/src/main/mima-filters/1.3.5.backwards.excludes/309-implicits-in-companion-objects.excludes
@@ -1,0 +1,6 @@
+# Adding an explicit return type also made the generic signature more accurate with Scala 2.10, 2.11
+# The descriptor itself didn't change. The semantics didn't change so it shouldn't have any impact on Scala programs.
+ProblemFilters.exclude[IncompatibleSignatureProblem]("spray.json.DefaultJsonProtocol.rootJsonFormat")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("spray.json.DefaultJsonProtocol.lazyFormat")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("spray.json.DefaultJsonProtocol.rootFormat")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("spray.json.DefaultJsonProtocol.safeReader")

--- a/spray-json/jvm/src/main/scala/spray/json/ProductFormats.scala
+++ b/spray-json/jvm/src/main/scala/spray/json/ProductFormats.scala
@@ -45,8 +45,8 @@ trait ProductFormats extends ProductFormatsInstances {
   protected def productElement2Field[T](fieldName: String, p: Product, ix: Int, rest: List[JsField] = Nil)(implicit writer: JsonWriter[T]): List[JsField] = {
     val value = p.productElement(ix).asInstanceOf[T]
     writer match {
-      case _: OptionFormat[_] if (value == None) => rest
-      case _                                     => (fieldName, writer.write(value)) :: rest
+      case _: StandardFormats#OptionFormat[_] if (value == None) => rest
+      case _ => (fieldName, writer.write(value)) :: rest
     }
   }
 

--- a/spray-json/shared/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
+++ b/spray-json/shared/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2011,2012 Mathias Doenitz, Johannes Rudolph
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spray.json
+
+trait TupleFormatInstances {
+  [2..22#implicit def tuple2Format[[#T1: JsonFormat#]]: JsonFormat[Tuple1[[#T1#]]] = new JsonFormat[Tuple1[[#T1#]]] {
+    def write(t: ([#T1#])) = JsArray([#t._1.toJson#])
+    def read(value: JsValue) = value match {
+      case JsArray(Seq([#t1#])) => Tuple1([#t1.convertTo[T1]#])
+      case x                  => deserializationError("Expected Tuple1 as JsArray, but got " + x)
+    }
+  }#
+
+  ]
+}

--- a/spray-json/shared/src/main/scala/spray/json/AdditionalFormats.scala
+++ b/spray-json/shared/src/main/scala/spray/json/AdditionalFormats.scala
@@ -17,22 +17,28 @@
 
 package spray.json
 
+trait AdditionalFormatsImplicits {
+  implicit val jsValueFormat: JsonFormat[JsValue] = AdditionalFormats.JsValueFormat
+  implicit val jsObjectFormat: JsonFormat[JsObject] = AdditionalFormats.RootJsObjectFormat
+  implicit val jsArrayFormat: JsonFormat[JsArray] = AdditionalFormats.RootJsArrayFormat
+}
+
 /**
  * Provides additional JsonFormats and helpers
  */
 trait AdditionalFormats {
 
-  implicit object JsValueFormat extends JsonFormat[JsValue] {
+  object JsValueFormat extends JsonFormat[JsValue] {
     def write(value: JsValue) = value
     def read(value: JsValue) = value
   }
 
-  implicit object RootJsObjectFormat extends RootJsonFormat[JsObject] {
+  object RootJsObjectFormat extends RootJsonFormat[JsObject] {
     def write(value: JsObject) = value
     def read(value: JsValue) = value.asJsObject
   }
 
-  implicit object RootJsArrayFormat extends RootJsonFormat[JsArray] {
+  object RootJsArrayFormat extends RootJsonFormat[JsArray] {
     def write(value: JsArray) = value
     def read(value: JsValue) = value match {
       case x: JsArray => x
@@ -115,3 +121,4 @@ trait AdditionalFormats {
   }
 
 }
+object AdditionalFormats extends AdditionalFormats

--- a/spray-json/shared/src/main/scala/spray/json/AdditionalFormats.scala
+++ b/spray-json/shared/src/main/scala/spray/json/AdditionalFormats.scala
@@ -93,16 +93,16 @@ trait AdditionalFormats {
   /**
    * Lazy wrapper around serialization. Useful when you want to serialize (mutually) recursive structures.
    */
-  def lazyFormat[T](format: => JsonFormat[T]) = new JsonFormat[T] {
-    lazy val delegate = format;
-    def write(x: T) = delegate.write(x);
-    def read(value: JsValue) = delegate.read(value);
+  def lazyFormat[T](format: => JsonFormat[T]): JsonFormat[T] = new JsonFormat[T] {
+    lazy val delegate = format
+    def write(x: T) = delegate.write(x)
+    def read(value: JsValue) = delegate.read(value)
   }
 
   /**
    * Explicitly turns a JsonFormat into a RootJsonFormat.
    */
-  def rootFormat[T](format: JsonFormat[T]) = new RootJsonFormat[T] {
+  def rootFormat[T](format: JsonFormat[T]): RootJsonFormat[T] = new RootJsonFormat[T] {
     def write(obj: T) = format.write(obj)
     def read(json: JsValue) = format.read(json)
   }
@@ -110,7 +110,7 @@ trait AdditionalFormats {
   /**
    * Wraps an existing JsonReader with Exception protection.
    */
-  def safeReader[A: JsonReader] = new JsonReader[Either[Exception, A]] {
+  def safeReader[A: JsonReader]: JsonReader[Either[Exception, A]] = new JsonReader[Either[Exception, A]] {
     def read(json: JsValue) = {
       try {
         Right(json.convertTo[A])

--- a/spray-json/shared/src/main/scala/spray/json/BasicFormats.scala
+++ b/spray-json/shared/src/main/scala/spray/json/BasicFormats.scala
@@ -17,12 +17,28 @@
 
 package spray.json
 
+trait BasicFormatsImplicits {
+  implicit val intFormat: JsonFormat[Int] = BasicFormats.IntJsonFormat
+  implicit val longFormat: JsonFormat[Long] = BasicFormats.LongJsonFormat
+  implicit val floatFormat: JsonFormat[Float] = BasicFormats.FloatJsonFormat
+  implicit val doubleFormat: JsonFormat[Double] = BasicFormats.DoubleJsonFormat
+  implicit val byteFormat: JsonFormat[Byte] = BasicFormats.ByteJsonFormat
+  implicit val shortFormat: JsonFormat[Short] = BasicFormats.ShortJsonFormat
+  implicit val bigDecimalFormat: JsonFormat[BigDecimal] = BasicFormats.BigDecimalJsonFormat
+  implicit val bigIntFormat: JsonFormat[BigInt] = BasicFormats.BigIntJsonFormat
+  implicit val unitFormat: JsonFormat[Unit] = BasicFormats.UnitJsonFormat
+  implicit val booleanFormat: JsonFormat[Boolean] = BasicFormats.BooleanJsonFormat
+  implicit val charFormat: JsonFormat[Char] = BasicFormats.CharJsonFormat
+  implicit val stringFormat: JsonFormat[String] = BasicFormats.StringJsonFormat
+  implicit val symbolFormat: JsonFormat[Symbol] = BasicFormats.SymbolJsonFormat
+}
+
 /**
  * Provides the JsonFormats for the most important Scala types.
  */
 trait BasicFormats {
 
-  implicit object IntJsonFormat extends JsonFormat[Int] {
+  object IntJsonFormat extends JsonFormat[Int] {
     def write(x: Int) = JsNumber(x)
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.intValue
@@ -30,7 +46,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object LongJsonFormat extends JsonFormat[Long] {
+  object LongJsonFormat extends JsonFormat[Long] {
     def write(x: Long) = JsNumber(x)
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.longValue
@@ -38,7 +54,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object FloatJsonFormat extends JsonFormat[Float] {
+  object FloatJsonFormat extends JsonFormat[Float] {
     def write(x: Float) = JsNumber(x)
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.floatValue
@@ -47,7 +63,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object DoubleJsonFormat extends JsonFormat[Double] {
+  object DoubleJsonFormat extends JsonFormat[Double] {
     def write(x: Double) = JsNumber(x)
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.doubleValue
@@ -56,7 +72,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object ByteJsonFormat extends JsonFormat[Byte] {
+  object ByteJsonFormat extends JsonFormat[Byte] {
     def write(x: Byte) = JsNumber(x)
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.byteValue
@@ -64,7 +80,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object ShortJsonFormat extends JsonFormat[Short] {
+  object ShortJsonFormat extends JsonFormat[Short] {
     def write(x: Short) = JsNumber(x)
     def read(value: JsValue) = value match {
       case JsNumber(x) => x.shortValue
@@ -72,7 +88,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object BigDecimalJsonFormat extends JsonFormat[BigDecimal] {
+  object BigDecimalJsonFormat extends JsonFormat[BigDecimal] {
     def write(x: BigDecimal) = {
       require(x ne null)
       JsNumber(x)
@@ -84,7 +100,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object BigIntJsonFormat extends JsonFormat[BigInt] {
+  object BigIntJsonFormat extends JsonFormat[BigInt] {
     def write(x: BigInt) = {
       require(x ne null)
       JsNumber(x)
@@ -96,12 +112,12 @@ trait BasicFormats {
     }
   }
 
-  implicit object UnitJsonFormat extends JsonFormat[Unit] {
+  object UnitJsonFormat extends JsonFormat[Unit] {
     def write(x: Unit) = JsNumber(1)
     def read(value: JsValue): Unit = {}
   }
 
-  implicit object BooleanJsonFormat extends JsonFormat[Boolean] {
+  object BooleanJsonFormat extends JsonFormat[Boolean] {
     def write(x: Boolean) = JsBoolean(x)
     def read(value: JsValue) = value match {
       case JsTrue  => true
@@ -110,7 +126,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object CharJsonFormat extends JsonFormat[Char] {
+  object CharJsonFormat extends JsonFormat[Char] {
     def write(x: Char) = JsString(String.valueOf(x))
     def read(value: JsValue) = value match {
       case JsString(x) if x.length == 1 => x.charAt(0)
@@ -118,7 +134,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object StringJsonFormat extends JsonFormat[String] {
+  object StringJsonFormat extends JsonFormat[String] {
     def write(x: String) = {
       require(x ne null)
       JsString(x)
@@ -129,7 +145,7 @@ trait BasicFormats {
     }
   }
 
-  implicit object SymbolJsonFormat extends JsonFormat[Symbol] {
+  object SymbolJsonFormat extends JsonFormat[Symbol] {
     def write(x: Symbol) = JsString(x.name)
     def read(value: JsValue) = value match {
       case JsString(x) => Symbol(x)
@@ -137,3 +153,4 @@ trait BasicFormats {
     }
   }
 }
+object BasicFormats extends BasicFormats

--- a/spray-json/shared/src/main/scala/spray/json/CollectionFormats.scala
+++ b/spray-json/shared/src/main/scala/spray/json/CollectionFormats.scala
@@ -19,15 +19,38 @@ package spray.json
 
 import scala.reflect.ClassTag
 
+trait CollectionFormatsImplicits {
+  implicit def listFormat[T: JsonFormat]: JsonFormat[List[T]] = CollectionFormats.listFormat[T]
+  implicit def arrayFormat[T: JsonFormat: ClassTag]: JsonFormat[Array[T]] = CollectionFormats.arrayFormat[T]
+  implicit def mapFormat[K: JsonFormat, V: JsonFormat]: JsonFormat[Map[K, V]] = CollectionFormats.mapFormat[K, V]
+
+  import collection.{ immutable => imm }
+
+  implicit def immIterableFormat[T: JsonFormat]: JsonFormat[imm.Iterable[T]] = CollectionFormats.immIterableFormat[T]
+  implicit def immSeqFormat[T: JsonFormat]: JsonFormat[imm.Seq[T]] = CollectionFormats.immSeqFormat[T]
+  implicit def immIndexedSeqFormat[T: JsonFormat]: JsonFormat[imm.IndexedSeq[T]] = CollectionFormats.immIndexedSeqFormat[T]
+  implicit def immLinearSeqFormat[T: JsonFormat]: JsonFormat[imm.LinearSeq[T]] = CollectionFormats.immLinearSeqFormat[T]
+  implicit def immSetFormat[T: JsonFormat]: JsonFormat[imm.Set[T]] = CollectionFormats.immSetFormat[T]
+  implicit def vectorFormat[T: JsonFormat]: JsonFormat[imm.Vector[T]] = CollectionFormats.vectorFormat[T]
+
+  import collection._
+
+  implicit def iterableFormat[T: JsonFormat]: JsonFormat[Iterable[T]] = CollectionFormats.iterableFormat[T]
+  implicit def seqFormat[T: JsonFormat]: JsonFormat[Seq[T]] = CollectionFormats.seqFormat[T]
+  implicit def indexedSeqFormat[T: JsonFormat]: JsonFormat[IndexedSeq[T]] = CollectionFormats.indexedSeqFormat[T]
+  implicit def linearSeqFormat[T: JsonFormat]: JsonFormat[LinearSeq[T]] = CollectionFormats.linearSeqFormat[T]
+  implicit def setFormat[T: JsonFormat]: JsonFormat[Set[T]] = CollectionFormats.setFormat[T]
+}
+
 trait CollectionFormats {
 
   /**
    * Supplies the JsonFormat for Lists.
    */
-  implicit def listFormat[T: JsonFormat] = new RootJsonFormat[List[T]] {
+  def listFormat[T: JsonFormat] = new RootJsonFormat[List[T]] {
     def write(list: List[T]) = JsArray(list.map(_.toJson).toVector)
     def read(value: JsValue): List[T] = value match {
-      case JsArray(elements) => elements.toIterator.map(_.convertTo[T]).toList
+      case JsArray(elements) => elements.iterator.map(_.convertTo[T]).toList
       case x                 => deserializationError("Expected List as JsArray, but got " + x)
     }
   }
@@ -35,7 +58,7 @@ trait CollectionFormats {
   /**
    * Supplies the JsonFormat for Arrays.
    */
-  implicit def arrayFormat[T: JsonFormat: ClassTag] = new RootJsonFormat[Array[T]] {
+  def arrayFormat[T: JsonFormat: ClassTag] = new RootJsonFormat[Array[T]] {
     def write(array: Array[T]) = JsArray(array.map(_.toJson).toVector)
     def read(value: JsValue) = value match {
       case JsArray(elements) => elements.map(_.convertTo[T]).toArray[T]
@@ -47,7 +70,7 @@ trait CollectionFormats {
    * Supplies the JsonFormat for Maps. The implicitly available JsonFormat for the key type K must
    * always write JsStrings, otherwise a [[spray.json.SerializationException]] will be thrown.
    */
-  implicit def mapFormat[K: JsonFormat, V: JsonFormat] = new RootJsonFormat[Map[K, V]] {
+  def mapFormat[K: JsonFormat, V: JsonFormat] = new RootJsonFormat[Map[K, V]] {
     def write(m: Map[K, V]) = JsObject {
       m.map { field =>
         field._1.toJson match {
@@ -66,20 +89,20 @@ trait CollectionFormats {
 
   import collection.{ immutable => imm }
 
-  implicit def immIterableFormat[T: JsonFormat] = viaSeq[imm.Iterable[T], T](seq => imm.Iterable(seq: _*))
-  implicit def immSeqFormat[T: JsonFormat] = viaSeq[imm.Seq[T], T](seq => imm.Seq(seq: _*))
-  implicit def immIndexedSeqFormat[T: JsonFormat] = viaSeq[imm.IndexedSeq[T], T](seq => imm.IndexedSeq(seq: _*))
-  implicit def immLinearSeqFormat[T: JsonFormat] = viaSeq[imm.LinearSeq[T], T](seq => imm.LinearSeq(seq: _*))
-  implicit def immSetFormat[T: JsonFormat] = viaSeq[imm.Set[T], T](seq => imm.Set(seq: _*))
-  implicit def vectorFormat[T: JsonFormat] = viaSeq[Vector[T], T](seq => Vector(seq: _*))
+  def immIterableFormat[T: JsonFormat] = viaSeq[imm.Iterable[T], T](seq => imm.Iterable(seq: _*))
+  def immSeqFormat[T: JsonFormat] = viaSeq[imm.Seq[T], T](seq => imm.Seq(seq: _*))
+  def immIndexedSeqFormat[T: JsonFormat] = viaSeq[imm.IndexedSeq[T], T](seq => imm.IndexedSeq(seq: _*))
+  def immLinearSeqFormat[T: JsonFormat] = viaSeq[imm.LinearSeq[T], T](seq => imm.LinearSeq(seq: _*))
+  def immSetFormat[T: JsonFormat] = viaSeq[imm.Set[T], T](seq => imm.Set(seq: _*))
+  def vectorFormat[T: JsonFormat] = viaSeq[Vector[T], T](seq => Vector(seq: _*))
 
   import collection._
 
-  implicit def iterableFormat[T: JsonFormat] = viaSeq[Iterable[T], T](seq => Iterable(seq: _*))
-  implicit def seqFormat[T: JsonFormat] = viaSeq[Seq[T], T](seq => Seq(seq: _*))
-  implicit def indexedSeqFormat[T: JsonFormat] = viaSeq[IndexedSeq[T], T](seq => IndexedSeq(seq: _*))
-  implicit def linearSeqFormat[T: JsonFormat] = viaSeq[LinearSeq[T], T](seq => LinearSeq(seq: _*))
-  implicit def setFormat[T: JsonFormat] = viaSeq[Set[T], T](seq => Set(seq: _*))
+  def iterableFormat[T: JsonFormat] = viaSeq[Iterable[T], T](seq => Iterable(seq: _*))
+  def seqFormat[T: JsonFormat] = viaSeq[Seq[T], T](seq => Seq(seq: _*))
+  def indexedSeqFormat[T: JsonFormat] = viaSeq[IndexedSeq[T], T](seq => IndexedSeq(seq: _*))
+  def linearSeqFormat[T: JsonFormat] = viaSeq[LinearSeq[T], T](seq => LinearSeq(seq: _*))
+  def setFormat[T: JsonFormat] = viaSeq[Set[T], T](seq => Set(seq: _*))
 
   /**
    * A JsonFormat construction helper that creates a JsonFormat for an Iterable type I from a builder function
@@ -93,3 +116,4 @@ trait CollectionFormats {
     }
   }
 }
+object CollectionFormats extends CollectionFormats

--- a/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
+++ b/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
@@ -56,6 +56,7 @@ trait JsonFormat[T] extends JsonReader[T] with JsonWriter[T]
 
 object JsonFormat
   extends AdditionalFormatsImplicits
+  with BasicFormatsImplicits
 
 /**
  * A special JsonReader capable of reading a legal JSON root object, i.e. either a JSON array or a JSON object.

--- a/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
+++ b/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
@@ -31,6 +31,7 @@ object JsonReader {
   implicit def func2Reader[T](f: JsValue => T): JsonReader[T] = new JsonReader[T] {
     def read(json: JsValue) = f(json)
   }
+  implicit def readerFromFormat[T](implicit format: JsonFormat[T]): JsonReader[T] = format
 }
 
 /**
@@ -45,12 +46,16 @@ object JsonWriter {
   implicit def func2Writer[T](f: T => JsValue): JsonWriter[T] = new JsonWriter[T] {
     def write(obj: T) = f(obj)
   }
+  implicit def writerFromFormat[T](implicit format: JsonFormat[T]): JsonWriter[T] = format
 }
 
 /**
  * Provides the JSON deserialization and serialization for type T.
  */
 trait JsonFormat[T] extends JsonReader[T] with JsonWriter[T]
+
+object JsonFormat
+  extends AdditionalFormatsImplicits
 
 /**
  * A special JsonReader capable of reading a legal JSON root object, i.e. either a JSON array or a JSON object.

--- a/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
+++ b/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
@@ -57,6 +57,7 @@ trait JsonFormat[T] extends JsonReader[T] with JsonWriter[T]
 object JsonFormat
   extends AdditionalFormatsImplicits
   with BasicFormatsImplicits
+  with CollectionFormatsImplicits
 
 /**
  * A special JsonReader capable of reading a legal JSON root object, i.e. either a JSON array or a JSON object.

--- a/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
+++ b/spray-json/shared/src/main/scala/spray/json/JsonFormat.scala
@@ -58,6 +58,7 @@ object JsonFormat
   extends AdditionalFormatsImplicits
   with BasicFormatsImplicits
   with CollectionFormatsImplicits
+  with StandardFormatsImplicits
 
 /**
  * A special JsonReader capable of reading a legal JSON root object, i.e. either a JSON array or a JSON object.

--- a/spray-json/shared/src/main/scala/spray/json/StandardFormats.scala
+++ b/spray-json/shared/src/main/scala/spray/json/StandardFormats.scala
@@ -19,6 +19,12 @@ package spray.json
 
 import scala.{ Left, Right }
 
+trait StandardFormatsImplicits extends TupleFormatInstances {
+  implicit def optionFormat[T: JsonFormat]: JsonFormat[Option[T]] = StandardFormats.optionFormat[T]
+  implicit def eitherFormat[A: JsonFormat, B: JsonFormat]: JsonFormat[Either[A, B]] = StandardFormats.eitherFormat[A, B]
+  implicit def tuple1Format[A: JsonFormat]: JsonFormat[Tuple1[A]] = StandardFormats.tuple1Format[A]
+}
+
 /**
  * Provides the JsonFormats for the non-collection standard types.
  */
@@ -27,7 +33,7 @@ trait StandardFormats {
 
   private[json] type JF[T] = JsonFormat[T] // simple alias for reduced verbosity
 
-  implicit def optionFormat[T: JF]: JF[Option[T]] = new OptionFormat[T]
+  def optionFormat[T: JF]: JF[Option[T]] = new OptionFormat[T]
 
   class OptionFormat[T: JF] extends JF[Option[T]] {
     def write(option: Option[T]) = option match {
@@ -42,7 +48,7 @@ trait StandardFormats {
     def readSome(value: JsValue) = Some(value.convertTo[T])
   }
 
-  implicit def eitherFormat[A: JF, B: JF] = new JF[Either[A, B]] {
+  def eitherFormat[A: JF, B: JF] = new JF[Either[A, B]] {
     def write(either: Either[A, B]) = either match {
       case Right(a) => a.toJson
       case Left(b)  => b.toJson
@@ -55,12 +61,12 @@ trait StandardFormats {
     }
   }
 
-  implicit def tuple1Format[A: JF] = new JF[Tuple1[A]] {
+  def tuple1Format[A: JF] = new JF[Tuple1[A]] {
     def write(t: Tuple1[A]) = t._1.toJson
     def read(value: JsValue) = Tuple1(value.convertTo[A])
   }
 
-  implicit def tuple2Format[A: JF, B: JF] = new RootJsonFormat[(A, B)] {
+  def tuple2Format[A: JF, B: JF] = new RootJsonFormat[(A, B)] {
     def write(t: (A, B)) = JsArray(t._1.toJson, t._2.toJson)
     def read(value: JsValue) = value match {
       case JsArray(Seq(a, b)) => (a.convertTo[A], b.convertTo[B])
@@ -68,7 +74,7 @@ trait StandardFormats {
     }
   }
 
-  implicit def tuple3Format[A: JF, B: JF, C: JF] = new RootJsonFormat[(A, B, C)] {
+  def tuple3Format[A: JF, B: JF, C: JF] = new RootJsonFormat[(A, B, C)] {
     def write(t: (A, B, C)) = JsArray(t._1.toJson, t._2.toJson, t._3.toJson)
     def read(value: JsValue) = value match {
       case JsArray(Seq(a, b, c)) => (a.convertTo[A], b.convertTo[B], c.convertTo[C])
@@ -76,7 +82,7 @@ trait StandardFormats {
     }
   }
 
-  implicit def tuple4Format[A: JF, B: JF, C: JF, D: JF] = new RootJsonFormat[(A, B, C, D)] {
+  def tuple4Format[A: JF, B: JF, C: JF, D: JF] = new RootJsonFormat[(A, B, C, D)] {
     def write(t: (A, B, C, D)) = JsArray(t._1.toJson, t._2.toJson, t._3.toJson, t._4.toJson)
     def read(value: JsValue) = value match {
       case JsArray(Seq(a, b, c, d)) => (a.convertTo[A], b.convertTo[B], c.convertTo[C], d.convertTo[D])
@@ -84,7 +90,7 @@ trait StandardFormats {
     }
   }
 
-  implicit def tuple5Format[A: JF, B: JF, C: JF, D: JF, E: JF] = {
+  def tuple5Format[A: JF, B: JF, C: JF, D: JF, E: JF] = {
     new RootJsonFormat[(A, B, C, D, E)] {
       def write(t: (A, B, C, D, E)) = JsArray(t._1.toJson, t._2.toJson, t._3.toJson, t._4.toJson, t._5.toJson)
       def read(value: JsValue) = value match {
@@ -95,7 +101,7 @@ trait StandardFormats {
     }
   }
 
-  implicit def tuple6Format[A: JF, B: JF, C: JF, D: JF, E: JF, F: JF] = {
+  def tuple6Format[A: JF, B: JF, C: JF, D: JF, E: JF, F: JF] = {
     new RootJsonFormat[(A, B, C, D, E, F)] {
       def write(t: (A, B, C, D, E, F)) = JsArray(t._1.toJson, t._2.toJson, t._3.toJson, t._4.toJson, t._5.toJson, t._6.toJson)
       def read(value: JsValue) = value match {
@@ -106,7 +112,7 @@ trait StandardFormats {
     }
   }
 
-  implicit def tuple7Format[A: JF, B: JF, C: JF, D: JF, E: JF, F: JF, G: JF] = {
+  def tuple7Format[A: JF, B: JF, C: JF, D: JF, E: JF, F: JF, G: JF] = {
     new RootJsonFormat[(A, B, C, D, E, F, G)] {
       def write(t: (A, B, C, D, E, F, G)) = JsArray(t._1.toJson, t._2.toJson, t._3.toJson, t._4.toJson, t._5.toJson, t._6.toJson, t._7.toJson)
       def read(value: JsValue) = value match {
@@ -118,3 +124,4 @@ trait StandardFormats {
   }
 
 }
+object StandardFormats extends StandardFormats with AdditionalFormats

--- a/spray-json/shared/src/test/scala/spray/json/AdditionalFormatsSpec.scala
+++ b/spray-json/shared/src/test/scala/spray/json/AdditionalFormatsSpec.scala
@@ -18,7 +18,7 @@ package spray.json
 
 import org.specs2.mutable._
 
-class AdditionalFormatsSpec extends Specification {
+class AdditionalFormatsSpec extends Specification with RoundTripSpecBase {
 
   case class Container[A](inner: Option[A])
 
@@ -68,6 +68,52 @@ class AdditionalFormatsSpec extends Specification {
 
       json mustEqual
         """{"id":1,"name":"a","foos":[{"id":2,"name":"b","foos":[{"id":3,"name":"c"}]},{"id":4,"name":"d"}]}""".parseJson
+    }
+  }
+
+  "AdditionalFormats" should {
+    "provide implicits (with DefaultJsonProtocol import) for" in {
+      "JsValue" in {
+        import DefaultJsonProtocol._ // check that no implicits conflict
+        safeReader[JsValue] // dummy to silence unused warning for above import
+
+        roundTrip[JsValue]("53", JsNumber(53))
+        roundTrip[JsValue]("[]", JsArray())
+        roundTrip[JsValue]("{}", JsObject())
+        roundTrip[JsValue]("\"test\"", JsString("test"))
+        roundTrip[JsValue]("[{}]", JsArray(JsObject()))
+      }
+      "JsObject" in {
+        import DefaultJsonProtocol._ // check that no implicits conflict
+        safeReader[JsObject] // dummy to silence unused warning for above import
+
+        roundTrip[JsObject]("{}", JsObject())
+        roundTrip[JsObject]("""{"a":42}""", JsObject("a" -> JsNumber(42)))
+      }
+      "JsArray" in {
+        import DefaultJsonProtocol._ // check that no implicits conflict
+        safeReader[JsArray] // dummy to silence unused warning for above import
+
+        roundTrip[JsArray]("[]", JsArray())
+        roundTrip[JsArray]("[1,2,3]", JsArray(Seq(1, 2, 3).map(JsNumber(_): JsValue): _*))
+      }
+    }
+    "provide implicits (without any import) for" in {
+      "JsValue" in {
+        roundTrip[JsValue]("53", JsNumber(53))
+        roundTrip[JsValue]("[]", JsArray())
+        roundTrip[JsValue]("{}", JsObject())
+        roundTrip[JsValue]("\"test\"", JsString("test"))
+        roundTrip[JsValue]("[{}]", JsArray(JsObject()))
+      }
+      "JsObject" in {
+        roundTrip[JsObject]("{}", JsObject())
+        roundTrip[JsObject]("""{"a":42}""", JsObject("a" -> JsNumber(42)))
+      }
+      "JsArray" in {
+        roundTrip[JsArray]("[]", JsArray())
+        roundTrip[JsArray]("[1,2,3]", JsArray(Seq(1, 2, 3).map(JsNumber(_): JsValue): _*))
+      }
     }
   }
 }

--- a/spray-json/shared/src/test/scala/spray/json/RoundTripSpecBase.scala
+++ b/spray-json/shared/src/test/scala/spray/json/RoundTripSpecBase.scala
@@ -1,0 +1,13 @@
+package spray.json
+
+import org.specs2.execute.Success
+import org.specs2.mutable.Specification
+
+trait RoundTripSpecBase extends Specification {
+  def roundTrip[T](json: String, expected: T)(implicit format: JsonFormat[T]): Success = {
+    val converted: T = json.parseJson.convertTo[T]
+    converted mustEqual expected
+    converted.toJson.compactPrint mustEqual json
+    success
+  }
+}

--- a/spray-json/shared/src/test/scala/spray/json/StandardFormatsSpec.scala
+++ b/spray-json/shared/src/test/scala/spray/json/StandardFormatsSpec.scala
@@ -53,6 +53,22 @@ class StandardFormatsSpec extends Specification with DefaultJsonProtocol {
       JsString("Hello").convertTo[Either[Int, String]] mustEqual Right("Hello")
     }
   }
+  "JsonReader" should {
+    "be automatically provided from JsonFormat" in {
+      trait X
+      implicit def format: JsonFormat[X] = ???
+      implicit def reader = implicitly[JsonReader[X]]
+      success
+    }
+  }
+  "JsonWriter" should {
+    "be automatically provided from JsonFormat" in {
+      trait X
+      implicit def format: JsonFormat[X] = ???
+      implicit def reader = implicitly[JsonWriter[X]]
+      success
+    }
+  }
 
   "The tuple1Format" should {
     "convert (42) to a JsNumber" in {

--- a/spray-json/spray-json/native/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
+++ b/spray-json/spray-json/native/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template
@@ -1,0 +1,1 @@
+../../../../../../shared/src/main/boilerplate/spray/json/TupleFormatInstances.scala.template


### PR DESCRIPTION
To keep it compatible we just remove the `implicit` marker for now and provide implicit forwarders in traits that are mixed into `JsonFormat`.

Later we should deprecate usage (and especially inheritance) of `BasicFormats` etc.  and recommend to use the methods in JsonFormat directly.

Refs #308.