### PR TITLE
Provide jsonFormatN methods instead of explicit numbers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,7 +120,7 @@ If your custom type `T` is a case class then augmenting the `DefaultJsonProtocol
 case class Color(name: String, red: Int, green: Int, blue: Int)
 
 object MyJsonProtocol extends DefaultJsonProtocol {
-  implicit val colorFormat = jsonFormat4(Color)
+  implicit val colorFormat = jsonFormatN(Color.apply)
 }
 
 import MyJsonProtocol._
@@ -130,28 +130,14 @@ val json = Color("CadetBlue", 95, 158, 160).toJson
 val color = json.convertTo[Color]
 ```
 
-The `jsonFormatX` methods reduce the boilerplate to a minimum, just pass the right one the companion object of your
-case class and it will return a ready-to-use `JsonFormat` for your type (the right one is the one matching the number
-of arguments to your case class constructor, e.g. if your case class has 13 fields you need to use the `jsonFormat13`
-method). The `jsonFormatX` methods try to extract the field names of your case class before calling the more general
+The `jsonFormatN` method reduces the boilerplate to a minimum, just pass the apply method and it will return a ready-to-use
+`JsonFormat` for your type. The `jsonFormatN` method tries to extract the field names of your case class before calling the more general
 `jsonFormat` overloads, which let you specify the field name manually. So, if spray-json has trouble determining the
 field names or if your JSON objects use member names that differ from the case class fields you can also use
 `jsonFormat` directly.
 
-*Note that spray-json for ScalaJS or Scala Native does not support the `jsonFormatX` methods, and hence using
+*Note that spray-json for ScalaJS or Scala Native does not support the `jsonFormatN` methods, and hence using
 the `jsonFormat` overloads is required on these platforms.*
-
-There is one additional quirk: If you explicitly declare the companion object for your case class the notation above will
-stop working. You'll have to explicitly refer to the companion objects `apply` method to fix this:
-
-```scala
-case class Color(name: String, red: Int, green: Int, blue: Int)
-object Color
-
-object MyJsonProtocol extends DefaultJsonProtocol {
-  implicit val colorFormat = jsonFormat4(Color.apply)
-}
-```
 
 If your case class is generic in that it takes type parameters itself the `jsonFormat` methods can also help you.
 However, there is a little more boilerplate required as you need to add context bounds for all type parameters
@@ -161,7 +147,7 @@ and explicitly refer to the case classes `apply` method as in this example:
 case class NamedList[A](name: String, items: List[A])
 
 object MyJsonProtocol extends DefaultJsonProtocol {
-  implicit def namedListFormat[A :JsonFormat] = jsonFormat2(NamedList.apply[A])
+  implicit def namedListFormat[A :JsonFormat] = jsonFormatN(NamedList.apply[A])
 }
 ```
 

--- a/spray-json/jvm/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
+++ b/spray-json/jvm/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
@@ -21,10 +21,30 @@ import scala.reflect.{ classTag, ClassTag }
 trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
 [#  // Case classes with 1 parameters
 
-  def jsonFormat1[[#P1 :JF#], T <: Product :ClassTag](construct: ([#P1#]) => T): RootJsonFormat[T] = {
+  /**
+   * Create a format for a case class, given the constructor for an instance.
+   *
+   * While creating the format (but not after), Java reflection is used to figure out the
+   * field names. JSON field names are then mapped 1-to-1 to case class field names. Use
+   * backtick-quoted field names for unusual field names.
+   *
+   * Recommended usage example:
+   *
+   * ```
+   *   case class Person(name: String, age: Int)
+   *   object Person {
+   *     implicit val personFormat = jsonFormatN(Person.apply _)
+   *   }
+   * ```
+   */
+  def jsonFormatN[[#P1 :JF#], T <: Product :ClassTag](construct: ([#P1#]) => T): RootJsonFormat[T] = {
     val Array([#p1#]) = extractFieldNames(classTag[T])
     jsonFormat(construct, [#p1#])
   }
+  @deprecated("Use jsonFormatN instead", since = "##1.4.##0")
+  def jsonFormat1[[#P1 :JF#], T <: Product :ClassTag](construct: ([#P1#]) => T): RootJsonFormat[T] =
+    jsonFormatN(construct)
+
   def jsonFormat[[#P1 :JF#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonFormat[T] = new RootJsonFormat[T]{
     def write(p: T) = {
       val fields = new collection.mutable.ListBuffer[(String, JsValue)]

--- a/spray-json/jvm/src/main/mima-filters/1.3.5.backwards.excludes/310-add-jsonFormatN-methods.excludes
+++ b/spray-json/jvm/src/main/mima-filters/1.3.5.backwards.excludes/310-add-jsonFormatN-methods.excludes
@@ -1,0 +1,5 @@
+# Addition of jsonFormatN method is not compatible in Scala 2.10 and 2.11 when a third-party
+# implementation of ProductFormatsInstances was provided and then the user tries to use jsonFormatN.
+# We accept that as an unlikely problem only happening with old Scala versions.
+ProblemFilters.exclude[ReversedMissingMethodProblem]("spray.json.ProductFormatsInstances.jsonFormatN")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("spray.json.ProductFormats.jsonFormatN")

--- a/spray-json/jvm/src/main/scala/spray/json/ProductFormats.scala
+++ b/spray-json/jvm/src/main/scala/spray/json/ProductFormats.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 trait ProductFormats extends ProductFormatsInstances {
   this: StandardFormats =>
 
-  def jsonFormat0[T](construct: () => T): RootJsonFormat[T] =
+  def jsonFormatN[T](construct: () => T): RootJsonFormat[T] =
     new RootJsonFormat[T] {
       def write(p: T) = JsObject()
       def read(value: JsValue) = value match {
@@ -36,6 +36,9 @@ trait ProductFormats extends ProductFormatsInstances {
         case _           => throw new DeserializationException("Object expected")
       }
     }
+  @deprecated("Use jsonFormatN instead", since = "1.4.0")
+  def jsonFormat0[T](construct: () => T): RootJsonFormat[T] =
+    jsonFormatN(construct)
 
   // helpers
 

--- a/spray-json/jvm/src/test/scala/spray/json/ProductFormatsSpec.scala
+++ b/spray-json/jvm/src/test/scala/spray/json/ProductFormatsSpec.scala
@@ -33,13 +33,13 @@ class ProductFormatsSpec extends Specification {
 
   trait TestProtocol {
     this: DefaultJsonProtocol =>
-    implicit val test0Format = jsonFormat0(Test0)
-    implicit val test2Format = jsonFormat2(Test2)
-    implicit def test3Format[A: JsonFormat, B: JsonFormat] = jsonFormat2(Test3.apply[A, B])
-    implicit def test4Format = jsonFormat1(Test4)
-    implicit def testTransientFormat = jsonFormat2(TestTransient)
-    implicit def testStaticFormat = jsonFormat2(TestStatic)
-    implicit def testMangledFormat = jsonFormat5(TestMangled)
+    implicit val test0Format = jsonFormatN(Test0)
+    implicit val test2Format = jsonFormatN(Test2.apply _)
+    implicit def test3Format[A: JsonFormat, B: JsonFormat] = jsonFormatN(Test3[A, B] _)
+    implicit def test4Format = jsonFormatN(Test4.apply _)
+    implicit def testTransientFormat = jsonFormatN(TestTransient)
+    implicit def testStaticFormat = jsonFormatN(TestStatic)
+    implicit def testMangledFormat = jsonFormatN(TestMangled)
   }
   object TestProtocol1 extends DefaultJsonProtocol with TestProtocol
   object TestProtocol2 extends DefaultJsonProtocol with TestProtocol with NullOptions
@@ -108,7 +108,7 @@ class ProductFormatsSpec extends Specification {
   }
   "A JsonFormat for a case class with 18 parameters and created with `jsonFormat`" should {
     object Test18Protocol extends DefaultJsonProtocol {
-      implicit val test18Format = jsonFormat18(Test18)
+      implicit val test18Format = jsonFormatN(Test18.apply _)
     }
     case class Test18(
       a1:  String,
@@ -144,10 +144,10 @@ class ProductFormatsSpec extends Specification {
   }
 
   "A JsonFormat for a generic case class with an explicitly provided type parameter" should {
-    "support the jsonFormat1 syntax" in {
+    "support the jsonFormatN syntax" in {
       case class Box[A](a: A)
       object BoxProtocol extends DefaultJsonProtocol {
-        implicit val boxFormat = jsonFormat1(Box[Int])
+        implicit val boxFormat = jsonFormatN(Box[Int] _)
       }
       import BoxProtocol._
       Box(42).toJson === JsObject(Map("a" -> JsNumber(42)))

--- a/spray-json/jvm/src/test/scala/spray/json/ReadmeSpec.scala
+++ b/spray-json/jvm/src/test/scala/spray/json/ReadmeSpec.scala
@@ -45,7 +45,7 @@ class ReadmeSpec extends Specification {
   "The case class example" should {
     "behave as expected" in {
       object MyJsonProtocol extends DefaultJsonProtocol {
-        implicit val colorFormat = jsonFormat4(Color)
+        implicit val colorFormat = jsonFormatN(Color.apply _)
       }
       import MyJsonProtocol._
       color.toJson.convertTo[Color] mustEqual color


### PR DESCRIPTION
The main drawback is that you always have to write `jsonFormatN(X.apply _)`
instead of `jsonFormat15(X)` which worked before if `X` had no companion object.

The trade-off seems still worthwhile, needs a bit of relearning but then
it's much easier to add and remove fields.

Refs #310