### PR TITLE
Add UUID json format

### DIFF
--- a/spray-json/shared/src/main/scala/spray/json/BasicFormats.scala
+++ b/spray-json/shared/src/main/scala/spray/json/BasicFormats.scala
@@ -17,6 +17,10 @@
 
 package spray.json
 
+import java.util.UUID
+
+import scala.util.Try
+
 /**
  * Provides the JsonFormats for the most important Scala types.
  */
@@ -134,6 +138,22 @@ trait BasicFormats {
     def read(value: JsValue) = value match {
       case JsString(x) => Symbol(x)
       case x           => deserializationError("Expected Symbol as JsString, but got " + x)
+    }
+  }
+
+  implicit object UUIDJsonFormat extends JsonFormat[UUID] {
+    def write(x: UUID) = {
+      require(x ne null)
+      JsString(x.toString)
+    }
+    def read(value: JsValue) = {
+      def stringToUUID(s: String): UUID = Try(UUID.fromString(s))
+        .recover { case t => deserializationError("Expected a valid UUID, but got " + s) }
+        .get
+      value match {
+        case JsString(x) => stringToUUID(x)
+        case x           => deserializationError("Expected UUID as JsString, but got " + x)
+      }
     }
   }
 }

--- a/spray-json/shared/src/test/scala/spray/json/BasicFormatsSpec.scala
+++ b/spray-json/shared/src/test/scala/spray/json/BasicFormatsSpec.scala
@@ -16,6 +16,8 @@
 
 package spray.json
 
+import java.util.UUID
+
 import org.specs2.mutable._
 
 class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
@@ -162,6 +164,20 @@ class BasicFormatsSpec extends Specification with DefaultJsonProtocol {
     }
     "convert a JsString to a Symbol" in {
       JsString("Hello").convertTo[Symbol] mustEqual Symbol("Hello")
+    }
+  }
+
+  "The UUIDJsonFormat" should {
+    val good = "833a1d98-031e-4deb-b7cd-0f012c1d7e77"
+    val bad = "not_a_UUID"
+    "convert a UUID to a JsString" in {
+      UUID.fromString(good).toJson mustEqual JsString(good)
+    }
+    "convert a JsString to a UUID" in {
+      JsString(good).convertTo[UUID] mustEqual UUID.fromString(good)
+    }
+    "throw an Exception when trying to deserialize an invalid UUID String" in {
+      JsString(bad).convertTo[UUID] must throwA(new DeserializationException("Expected a valid UUID, but got " + bad))
     }
   }
 


### PR DESCRIPTION
This PR adds an instance of `JsonFormat[UUID]` as requested in https://github.com/spray/spray-json/issues/243.
I'm not sure as to where to place this object, currently `BasicFormats` is my best guess, but feel free to request any changes.

Closes https://github.com/spray/spray-json/issues/243