### PR TITLE
Deprecate old parsing infrastructure and provide new entry points

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,26 +49,33 @@ import DefaultJsonProtocol._ // if you don't supply your own Protocol (see below
 
 and do one or more of the following:
 
-1. Parse a JSON string into its Abstract Syntax Tree (AST) representation
+1. Directly parse a JSON document to a Scala object with the `parseJsonAs` method
 
     ```scala
     val source = """{ "some": "JSON source" }"""
-    val jsonAst = source.parseJson // or JsonParser(source)
+    val myObject = source.parseJsonAs[MyObjectType]
     ```
 
-2. Print a JSON AST back to a String using either the `CompactPrinter` or the `PrettyPrinter`
+2. Parse a JSON string into its Abstract Syntax Tree (AST) representation
+
+    ```scala
+    val source = """{ "some": "JSON source" }"""
+    val jsonAst = source.parseJson
+    ```
+
+3. Print a JSON AST back to a String using either the `CompactPrinter` or the `PrettyPrinter`
 
     ```scala
     val json = jsonAst.prettyPrint // or .compactPrint
     ```
 
-3. Convert any Scala object to a JSON AST using the `toJson` extension method
+4. Convert any Scala object to a JSON AST using the `toJson` extension method
 
     ```scala
     val jsonAst = List(1, 2, 3).toJson
     ```
 
-4. Convert a JSON AST to a Scala object with the `convertTo` method
+5. Convert a JSON AST to a Scala object with the `convertTo` method
 
     ```scala
     val myObject = jsonAst.convertTo[MyObjectType]
@@ -291,16 +298,14 @@ call to `rootFormat`.
 
 ### Customizing Parser Settings
 
-The parser can be customized by providing a custom instance of `JsonParserSettings` to `JsonParser.apply` or
-`String.parseJson`:
+The parser can be customized by providing a custom instance of `JsonParserSettings` to `parseJson` or
+`parseJsonAs`:
 
 ```scala
 val customSettings =
   JsonParserSettings.default
      .withMaxDepth(100)
      .withMaxNumberCharacters(20)
-val jsValue = JsonParser(jsonString, customSettings)
-// or
 val jsValue = jsonString.parseJson(customSettings)
 ```
 

--- a/spray-json/jvm/src/test/scala/spray/json/JsonParserSpecJvm.scala
+++ b/spray-json/jvm/src/test/scala/spray/json/JsonParserSpecJvm.scala
@@ -29,7 +29,7 @@ class JsonParserSpecJvm extends Specification {
 
       val largeJsonSource = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/test.json")).mkString
       val list = Await.result(
-        Future.traverse(List.fill(20)(largeJsonSource))(src => Future(JsonParser(src))),
+        Future.traverse(List.fill(20)(largeJsonSource))(src => Future(src.parseJson)),
         5.seconds
       )
       list.map(_.asInstanceOf[JsObject].fields("questions").asInstanceOf[JsArray].elements.size) === List.fill(20)(100)
@@ -45,7 +45,7 @@ class JsonParserSpecJvm extends Specification {
             try {
               val nested = "[{\"key\":" * (depth / 2)
               val settings = JsonParserSettings.default.withMaxDepth(maxDepth)
-              JsonParser(nested, settings)
+              nested.parseJson(settings)
               queue.push("didn't fail")
             } catch {
               case s: StackOverflowError => queue.push("stackoverflow")

--- a/spray-json/jvm/src/test/scala/spray/json/ProductFormatsSpec.scala
+++ b/spray-json/jvm/src/test/scala/spray/json/ProductFormatsSpec.scala
@@ -134,7 +134,7 @@ class ProductFormatsSpec extends Specification {
     val obj = Test18("a1", "a2", "a3", "a4", 5, "a6", "a7", "a8", "a9",
       "a10", "a11", 12d, "a13", "a14", "a15", "a16", "a17", "a18")
 
-    val json = JsonParser("""{"a1":"a1","a2":"a2","a3":"a3","a4":"a4","a5":5,"a6":"a6","a7":"a7","a8":"a8","a9":"a9","a10":"a10","a11":"a11","a12":12.0,"a13":"a13","a14":"a14","a15":"a15","a16":"a16","a17":"a17","a18":"a18"}""")
+    val json = """{"a1":"a1","a2":"a2","a3":"a3","a4":"a4","a5":5,"a6":"a6","a7":"a7","a8":"a8","a9":"a9","a10":"a10","a11":"a11","a12":12.0,"a13":"a13","a14":"a14","a15":"a15","a16":"a16","a17":"a17","a18":"a18"}""".parseJson
     "convert to a respective JsObject" in {
       obj.toJson mustEqual json
     }

--- a/spray-json/shared/src/main/scala/spray/json/Input.scala
+++ b/spray-json/shared/src/main/scala/spray/json/Input.scala
@@ -1,0 +1,21 @@
+package spray.json
+
+/**
+ * Type-class for any kind of data that can be used as input to JSON parsing.
+ *
+ * Custom inputs can be supported by implementing the RandomAccessBytes trait.
+ *
+ * Input itself is not supposed to be implemented by third parties.
+ */
+sealed trait Input[T] {
+  private[json] def parserInput(t: T): ParserInput
+}
+object Input {
+  private[json] def byParserInput[T](f: T => ParserInput): Input[T] = new Input[T] { def parserInput(t: T): ParserInput = f(t) }
+
+  implicit def forString: Input[String] = byParserInput(string => ParserInput(string))
+  implicit def forChars: Input[Array[Char]] = byParserInput(chars => ParserInput(chars))
+  implicit def forBytes: Input[Array[Byte]] = byParserInput(bytes => ParserInput(bytes))
+  implicit def forRandomAccessBytes(bytes: RandomAccessBytes): Input[RandomAccessBytes] =
+    byParserInput(bytes => bytes: ParserInput)
+}

--- a/spray-json/shared/src/main/scala/spray/json/JsonParser.scala
+++ b/spray-json/shared/src/main/scala/spray/json/JsonParser.scala
@@ -27,13 +27,16 @@ import scala.collection.immutable.TreeMap
  * Fast, no-dependency parser for JSON as defined by http://tools.ietf.org/html/rfc4627.
  */
 object JsonParser {
+  @deprecated("JsonParser APIs are now deprecated to allow for better evolution of the parser structure. Use spray.json.parseJsonAs or spray.json.parseJson, instead.", since = "1.4.0")
   def apply(input: ParserInput): JsValue = new JsonParser(input).parseJsValue()
+  @deprecated("JsonParser APIs are now deprecated to allow for better evolution of the parser structure. Use spray.json.parseJsonAs or spray.json.parseJson, instead.", since = "1.4.0")
   def apply(input: ParserInput, settings: JsonParserSettings): JsValue = new JsonParser(input, settings).parseJsValue()
 
   class ParsingException(val summary: String, val detail: String = "")
     extends RuntimeException(if (summary.isEmpty) detail else if (detail.isEmpty) summary else summary + ":" + detail)
 }
 
+@deprecated("Parser APIs and internals are now deprecated to allow for better evolution of the parser structure.", since = "1.4.0")
 class JsonParser(input: ParserInput, settings: JsonParserSettings = JsonParserSettings.default) {
   def this(input: ParserInput) = this(input, JsonParserSettings.default)
 
@@ -244,6 +247,9 @@ class JsonParser(input: ParserInput, settings: JsonParserSettings = JsonParserSe
   }
 }
 
+@deprecated(
+  "JsonParser internals are now deprecated to allow for better evolution of the parser structure." +
+    "Implement Input, instead, to support custom input data types", since = "1.4.0")
 trait ParserInput {
   /**
    * Advance the cursor and get the next char.
@@ -263,7 +269,7 @@ trait ParserInput {
   def sliceCharArray(start: Int, end: Int): Array[Char]
   def getLine(index: Int): ParserInput.Line
 }
-
+@deprecated("Parser APIs and internals are now deprecated to allow for better evolution of the parser structure.", since = "1.4.0")
 object ParserInput {
   private final val EOI = '\uFFFF' // compile-time constant
   private final val ErrorChar = '\uFFFD' // compile-time constant, universal UTF-8 replacement character '�'
@@ -299,6 +305,9 @@ object ParserInput {
   /**
    * ParserInput that allows to create a ParserInput from any randomly accessible indexed byte storage.
    */
+  @deprecated(
+    "JsonParser internals are now deprecated to allow for better evolution of the parser structure." +
+      "Implement Input, instead, to support custom input data types", since = "1.4.0")
   abstract class IndexedBytesParserInput extends DefaultParserInput {
     def length: Int
     protected def byteAt(offset: Int): Byte

--- a/spray-json/shared/src/main/scala/spray/json/RandomAccessBytes.scala
+++ b/spray-json/shared/src/main/scala/spray/json/RandomAccessBytes.scala
@@ -1,0 +1,25 @@
+package spray.json
+
+import spray.json.ParserInput.IndexedBytesParserInput
+
+/**
+ * Interface for random accessible data to be used as input for JSON parsing.
+ *
+ * Implement to allow parsing from other data structures than the predefined ones.
+ */
+trait RandomAccessBytes {
+  def byteAt(offset: Long): Byte
+  def length: Long
+}
+object RandomAccessBytes {
+  private[json] implicit def toParserInput(bytes: RandomAccessBytes): ParserInput = new IndexedBytesParserInput {
+    override protected def byteAt(offset: Int): Byte = bytes.byteAt(offset)
+    override def length: Int = bytes.length.toInt
+
+    // inefficent default implementations
+    override def sliceString(start: Int, end: Int): String =
+      new String((start until end).map(i => bytes.byteAt(i)).toArray, "utf8")
+    override def sliceCharArray(start: Int, end: Int): Array[Char] =
+      sliceString(start, end).toCharArray
+  }
+}

--- a/spray-json/shared/src/test/scala/spray/json/PrettyPrinterSpec.scala
+++ b/spray-json/shared/src/test/scala/spray/json/PrettyPrinterSpec.scala
@@ -23,7 +23,7 @@ class PrettyPrinterSpec extends Specification {
 
   "The PrettyPrinter" should {
     "print a more complicated JsObject nicely aligned" in {
-      val js = JsonParser {
+      val js =
         """{
           |  "Boolean no": false,
           |  "Boolean yes":true,
@@ -38,8 +38,7 @@ class PrettyPrinterSpec extends Specification {
           |    "array": [1, 2, { "yes":1, "no":0 }, ["a", "b", null], false]
           |  },
           |  "zero": 0
-          |}""".stripMargin
-      }
+          |}""".stripMargin.parseJson
       def fixedFieldOrder(js: JsValue): JsValue = js match {
         case JsObject(fields) => JsObject(ListMap(fields.toSeq.sortBy(_._1).map { case (k, v) => (k, fixedFieldOrder(v)) }: _*))
         case x                => x

--- a/spray-json/shared/src/test/scala/spray/json/SortedPrinterSpec.scala
+++ b/spray-json/shared/src/test/scala/spray/json/SortedPrinterSpec.scala
@@ -22,7 +22,7 @@ class SortedPrinterSpec extends Specification {
 
   "The SortedPrinter" should {
     "print a more complicated JsObject nicely aligned with fields sorted" in {
-      val obj = JsonParser {
+      val obj =
         """{
           |  "Unic\u00f8de" :  "Long string with newline\nescape",
           |  "Boolean no": false,
@@ -37,8 +37,8 @@ class SortedPrinterSpec extends Specification {
           |    "array": [1, 2, { "yes":1, "no":0 }, ["a", "b", null], false]
           |  },
           |  "Boolean yes":true
-          |}""".stripMargin
-      }
+          |}""".stripMargin.parseJson
+
       SortedPrinter(obj) mustEqual {
         """{
           |  "Boolean no": false,


### PR DESCRIPTION
The main entry points for parsing are now

 * spray.json.parseJsonAs -> parse JSON document to Scala object T directly
 * spray.json.parseJson -> parse JSON document to AST

There are also enrichments for the supported parser input types.

Inputs themselves are now closed down to String, Array[Char], Array[Byte], and
a more generic RandomAccessBytes that can be implemented by third parties.

Internally, we still use the current JsonParser infrastructure but that
will go (or not be used by default any more) in the future.