### PR TITLE
Preserve order of iterable in viaSeq

### DIFF
--- a/src/main/scala/spray/json/CollectionFormats.scala
+++ b/src/main/scala/spray/json/CollectionFormats.scala
@@ -86,7 +86,7 @@ trait CollectionFormats {
     * List => I.
    */
   def viaSeq[I <: Iterable[T], T :JsonFormat](f: imm.Seq[T] => I): RootJsonFormat[I] = new RootJsonFormat[I] {
-    def write(iterable: I) = JsArray(iterable.map(_.toJson).toVector)
+    def write(iterable: I) = JsArray(iterable.iterator.map(_.toJson).toVector)
     def read(value: JsValue) = value match {
       case JsArray(elements) => f(elements.map(_.convertTo[T]))
       case x => deserializationError("Expected Collection as JsArray, but got " + x)

--- a/src/test/scala/spray/json/CollectionFormatsSpec.scala
+++ b/src/test/scala/spray/json/CollectionFormatsSpec.scala
@@ -19,7 +19,11 @@ package spray.json
 import org.specs2.mutable._
 import java.util.Arrays
 
-class CollectionFormatsSpec extends Specification with DefaultJsonProtocol {
+import org.specs2.ScalaCheck
+
+import scala.collection.immutable.TreeSet
+
+class CollectionFormatsSpec extends Specification with DefaultJsonProtocol with ScalaCheck {
 
   "The listFormat" should {
     val list = List(1, 2, 3)
@@ -78,5 +82,10 @@ class CollectionFormatsSpec extends Specification with DefaultJsonProtocol {
       json.convertTo[collection.IndexedSeq[Int]] mustEqual seq
     }
   }
-  
+
+  "viaSeq" should {
+    "maintain order" in prop { s: TreeSet[Long] =>
+      viaSeq[TreeSet[Long], Long](TreeSet(_: _*)).write(s) must_== s.toList.toJson
+    }
+  }
 }


### PR DESCRIPTION
Add a general property to assert this behaviour.

Fixes #329