### PR TITLE
Add KeyableFormat for Map json serialization (#125).

### DIFF
--- a/src/main/scala/spray/json/CollectionFormats.scala
+++ b/src/main/scala/spray/json/CollectionFormats.scala
@@ -46,7 +46,27 @@ trait CollectionFormats {
   /**
    * Supplies the JsonFormat for Maps.
    */
-  implicit def mapFormat[K :KeyableFormat, V :JsonFormat] = new RootJsonFormat[Map[K, V]] {
+  def mapFormat[K :JsonFormat, V :JsonFormat] = new RootJsonFormat[Map[K, V]] {
+    def write(m: Map[K, V]) = JsObject {
+      m.map { field =>
+        field._1.toJson match {
+          case JsString(x) => x -> field._2.toJson
+          case x => throw new SerializationException("Map key must be formatted as JsString, not '" + x + "'")
+        }
+      }
+    }
+    def read(value: JsValue) = value match {
+      case x: JsObject => x.fields.map { field =>
+        (JsString(field._1).convertTo[K], field._2.convertTo[V])
+      }
+      case x => deserializationError("Expected Map as JsObject, but got " + x)
+    }
+  }
+
+  /**
+   * Supplies the JsonFormat for Maps.
+   */
+  implicit def keyableMapFormat[K :KeyableFormat, V :JsonFormat] = new RootJsonFormat[Map[K, V]] {
     def write(m: Map[K, V]) = JsObject {
       m.map { field =>
         field._1.toKey -> field._2.toJson

--- a/src/main/scala/spray/json/DefaultJsonProtocol.scala
+++ b/src/main/scala/spray/json/DefaultJsonProtocol.scala
@@ -26,5 +26,6 @@ trait DefaultJsonProtocol
         with CollectionFormats
         with ProductFormats
         with AdditionalFormats
+        with KeyableFormats
 
 object DefaultJsonProtocol extends DefaultJsonProtocol

--- a/src/main/scala/spray/json/KeyableFormat.scala
+++ b/src/main/scala/spray/json/KeyableFormat.scala
@@ -1,0 +1,11 @@
+package spray.json
+
+trait KeyableWriter[T] {
+  def write(obj: T): String
+}
+
+trait KeyableReader[T] {
+  def read(jsString: JsString): T
+}
+
+trait KeyableFormat[T] extends KeyableWriter[T] with KeyableReader[T]

--- a/src/main/scala/spray/json/KeyableFormats.scala
+++ b/src/main/scala/spray/json/KeyableFormats.scala
@@ -1,0 +1,9 @@
+package spray.json
+
+trait KeyableFormats {
+
+  implicit object StringKeyableFormat extends KeyableFormat[String] {
+    override def write(obj: String) = obj
+    override def read(json: JsString) = json.value
+  }
+}

--- a/src/main/scala/spray/json/package.scala
+++ b/src/main/scala/spray/json/package.scala
@@ -28,6 +28,7 @@ package object json {
 
   implicit def enrichAny[T](any: T) = new RichAny(any)
   implicit def enrichString(string: String) = new RichString(string)
+  implicit def enrichJsString[T](jsString: JsString) = new RichJsString(jsString)
 
   @deprecated("use enrichAny", "1.3.4")
   def pimpAny[T](any: T) = new PimpedAny(any)
@@ -42,6 +43,7 @@ package json {
 
   private[json] class RichAny[T](any: T) {
     def toJson(implicit writer: JsonWriter[T]): JsValue = writer.write(any)
+    def toKey(implicit writer: KeyableWriter[T]): String = writer.write(any)
   }
 
   private[json] class RichString(string: String) {
@@ -49,6 +51,10 @@ package json {
     def asJson: JsValue = parseJson
     def parseJson: JsValue = JsonParser(string)
     def parseJson(settings: JsonParserSettings): JsValue = JsonParser(string, settings)
+  }
+
+  private[json] class RichJsString(jsString: JsString) {
+    def fromKey[T](implicit reader: KeyableReader[T]): T = reader.read(jsString)
   }
 
   @deprecated("use RichAny", "1.3.4")

--- a/src/test/scala/spray/json/CollectionFormatsSpec.scala
+++ b/src/test/scala/spray/json/CollectionFormatsSpec.scala
@@ -52,8 +52,27 @@ class CollectionFormatsSpec extends Specification with DefaultJsonProtocol {
     "be able to convert a JsObject to a Map[String, Long]" in {
       json.convertTo[Map[String, Long]] mustEqual map
     }
-    "throw an Exception when trying to serialize a map whose key are not serialized to JsStrings" in {
-      Map(1 -> "a").toJson must throwA(new SerializationException("Map key must be formatted as JsString, not '1'"))
+    "convert a Map[Int, String] to a JsObject given a KeyableFormat" in {
+      implicit val keyableFormat: KeyableFormat[Int] = new KeyableFormat[Int] {
+        override def read(jsString: JsString) = jsString.value.toInt
+        override def write(obj: Int) = obj.toString
+      }
+
+      val map = Map(1 -> "a", 2 -> "b", 3 -> "c")
+      val json = JsObject("1" -> JsString("a"), "2" -> JsString("b"), "3" -> JsString("c"))
+
+      map.toJson mustEqual json
+    }
+    "be able to convert a JsObject to a Map[Int, String] given a KeyableFormat" in {
+      implicit val keyableFormat: KeyableFormat[Int] = new KeyableFormat[Int] {
+        override def read(jsString: JsString) = jsString.value.toInt
+        override def write(obj: Int) = obj.toString
+      }
+
+      val map = Map(1 -> "a", 2 -> "b", 3 -> "c")
+      val json = JsObject("1" -> JsString("a"), "2" -> JsString("b"), "3" -> JsString("c"))
+
+      json.convertTo[Map[Int, String]] mustEqual map
     }
   }
   


### PR DESCRIPTION
This PR aims both to resolve an unclear behavior of the `mapFormat` method and improve the extensibility of this method. The `mapFormat` method provides a `RootJsonFormat` to serialize `scala.Predef#Map`s as `JsObject`s and vice versa. 

## Uncertain behavior

The signature of the `mapFormat` method incorrectly implies that all types of keys are applicable to serialize a `Map` as a `JsObject` as long as these keys are serializable as `JsValue`. Thus trying to serialize a Map with a key which is not serialized as `JsString` results in a `SerializationException`.

This PR will modify the method signature such that an implicit `KeyableFormat` instead of a `JsonFormat` is required. A `KeyableFormat` implies that a key must be serializable as a `String` - the only valid key format in JSON - and it can be deserialized back from a `String`. This change will improve the type-safety of the method and prevent surprising `SerializationException`s while serializing a `Map` without a valid key format. 

## Extensibility

The newly introduced `KeyableFormat` trait is extendable and enables user to provide their own format to serialize their keys. A simple and probably most generous `KeyableFormat` for `String` is provided in the `KeyableFormats` object.

## Is this is a breaking change?

I would argue partially: The signature of an implicit method was changed by replacing the implicit `JsonFormat` argument for the key to an implicit `KeyableFormat` and the `DefaultJsonProtocol` provides the default `StringKeyableFormat`. Thus most users may not be affected by this change. Nevertheless it is a change in a public API and should be considered as breaking change.
