### PR TITLE
Fixed Option sometimes creating Some(null)s instead of Nones

### DIFF
--- a/src/main/scala/spray/json/StandardFormats.scala
+++ b/src/main/scala/spray/json/StandardFormats.scala
@@ -17,8 +17,6 @@
 
 package spray.json
 
-import scala.{Left, Right}
-
 /**
   * Provides the JsonFormats for the non-collection standard types.
  */
@@ -36,10 +34,10 @@ trait StandardFormats {
     }
     def read(value: JsValue) = value match {
       case JsNull => None
-      case x => Some(x.convertTo[T])
+      case x => Option(x.convertTo[T])
     }
     // allows reading the JSON as a Some (useful in container formats)
-    def readSome(value: JsValue) = Some(value.convertTo[T])
+    def readSome(value: JsValue) = Option(value.convertTo[T])
   }
 
   implicit def eitherFormat[A :JF, B :JF] = new JF[Either[A, B]] {


### PR DESCRIPTION
By using `Some(x.convertTo[T])`, if the implicit conversion resulted in a `null` for any reason, the result would be a `Some(null)` instead of the expected `None`.

The CI build is failing because:

```
spray.json.StandardFormats#OptionFormat has a different result type in current version, where it is scala.Option rather than scala.Some
```

Which should be reasonable.