### PR TITLE
Fix unexpectedly large sizeHint to jsonFormatN

### DIFF
--- a/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
+++ b/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template
@@ -27,11 +27,11 @@ trait ProductFormatsInstances { self: ProductFormats with StandardFormats =>
   }
   def jsonFormat[[#P1 :JF#], T <: Product](construct: ([#P1#]) => T, [#fieldName1: String#]): RootJsonFormat[T] = new RootJsonFormat[T]{
     def write(p: T) = {
-      val fields = new collection.mutable.ListBuffer[(String, JsValue)]
-      fields.sizeHint(1 * 2)
+      val fields = collection.immutable.Map.newBuilder[String, JsValue]
+      fields.sizeHint(1)
       [#fields ++= productElement##2Field[P1](fieldName1, p, 0)#
       ]
-      JsObject(fields.toSeq: _*)
+      JsObject(fields.result())
     }
     def read(value: JsValue) = {
       [#val p1V = fromField[P1](value, fieldName1)#


### PR DESCRIPTION
This fixes https://github.com/spray/spray-json/issues/340 and also changes `ListBuffer` to `Map.newBuilder` since that seems like the more obvious way to build a `Map`.