### PR TITLE
Move out OptionFormat from StandardFormats to allow mix with custom implicits modules

### DIFF
--- a/src/main/scala/spray/json/StandardFormats.scala
+++ b/src/main/scala/spray/json/StandardFormats.scala
@@ -29,19 +29,6 @@ trait StandardFormats {
 
   implicit def optionFormat[T :JF]: JF[Option[T]] = new OptionFormat[T]
 
-  class OptionFormat[T :JF] extends JF[Option[T]] {
-    def write(option: Option[T]) = option match {
-      case Some(x) => x.toJson
-      case None => JsNull
-    }
-    def read(value: JsValue) = value match {
-      case JsNull => None
-      case x => Some(x.convertTo[T])
-    }
-    // allows reading the JSON as a Some (useful in container formats)
-    def readSome(value: JsValue) = Some(value.convertTo[T])
-  }
-
   implicit def eitherFormat[A :JF, B :JF]: JF[Either[A, B]] = new JF[Either[A, B]] {
     def write(either: Either[A, B]) = either match {
       case Right(a) => a.toJson
@@ -117,4 +104,17 @@ trait StandardFormats {
     }
   }
   
+}
+
+class OptionFormat[T :JsonFormat] extends JsonFormat[Option[T]] {
+  def write(option: Option[T]) = option match {
+    case Some(x) => x.toJson
+    case None => JsNull
+  }
+  def read(value: JsValue) = value match {
+    case JsNull => None
+    case x => Some(x.convertTo[T])
+  }
+  // allows reading the JSON as a Some (useful in container formats)
+  def readSome(value: JsValue) = Some(value.convertTo[T])
 }

--- a/src/test/scala/spray/json/ProductFormatsSpec.scala
+++ b/src/test/scala/spray/json/ProductFormatsSpec.scala
@@ -51,6 +51,13 @@ class ProductFormatsSpec extends Specification {
     "convert to a respective JsObject" in {
       obj.toJson mustEqual json
     }
+    "support another instances module" in {
+      object MyImplicits extends DefaultJsonProtocol
+      import MyImplicits.optionFormat
+      implicit val test2Format: JsonFormat[Test2] = jsonFormat2(Test2)
+
+      Test2(42, None).toJson mustEqual JsObject("a" -> JsNumber(42))
+    }
     "convert a JsObject to the respective case class instance" in {
       json.convertTo[Test2] mustEqual obj
     }


### PR DESCRIPTION
To fix an issue with a custom implicits module due to `OptionFormat` being an inner class of `StandardFormats` breaking the match in `ProductFormats.productElement2Field` when custom module implicits are used: https://github.com/spray/spray-json/blob/a2b4986d17f8cc9c9080ecf46af8f69dc72be1d5/src/main/scala/spray/json/ProductFormats.scala#L46

Changes include a test case that reproduces the issue.

The patch is my original work and I license the work to the spray-json project under the project’s open source license.