### PR TITLE
Fix SCM coordinatates in the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,8 +97,8 @@ pomIncludeRepository := { _ => false }
 
 pomExtra :=
   <scm>
-    <url>git://github.com/spray/spray.git</url>
-    <connection>scm:git:git@github.com:spray/spray.git</connection>
+    <url>git://github.com/spray/spray-json.git</url>
+    <connection>scm:git:git@github.com:spray/spray-json.git</connection>
   </scm>
   <developers>
     <developer><id>sirthias</id><name>Mathias Doenitz</name></developer>


### PR DESCRIPTION
This change changes incorrectly set SCM URL and connection for the POM metadata