### PR TITLE
Remove workaround for `$outer` not marked `synthetic`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
   - 2.11.12
   - 2.12.12
   - 2.13.3
-  - 3.1.0
+  - 3.1.2
 
 before_install:
   # make comparing to origin/master work

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ mimaBinaryIssueFilters := Seq(
 // publishing
 ///////////////
 
-crossScalaVersions := Seq("2.12.12", "2.10.7", "2.11.12", "2.13.3", "3.1.0")
+crossScalaVersions := Seq("2.12.12", "2.10.7", "2.11.12", "2.13.3", "3.1.2")
 
 publishMavenStyle := true
 

--- a/src/main/scala/spray/json/ProductFormats.scala
+++ b/src/main/scala/spray/json/ProductFormats.scala
@@ -74,9 +74,7 @@ trait ProductFormats extends ProductFormatsInstances {
         _.getName.drop("copy$default$".length).takeWhile(_ != '(').toInt)
       val fields = clazz.getDeclaredFields.filterNot { f =>
         import Modifier._
-        // We're considering any generated $outer methods as synthetic as well
-        // https://github.com/lampepfl/dotty/issues/14083
-        (f.getModifiers & (TRANSIENT | STATIC | 0x1000 /* SYNTHETIC*/)) > 0 || f.getName.endsWith("$outer")
+        (f.getModifiers & (TRANSIENT | STATIC | 0x1000 /* SYNTHETIC*/)) > 0
       }
       if (copyDefaultMethods.length != fields.length)
         sys.error("Case class " + clazz.getName + " declares additional fields")


### PR DESCRIPTION
https://github.com/lampepfl/dotty/issues/14083 was fixed in Scala 3.1.2.